### PR TITLE
Bind max size inputs to string

### DIFF
--- a/CardCreator/MainWindow.xaml
+++ b/CardCreator/MainWindow.xaml
@@ -93,9 +93,9 @@
                         <TextBlock Text="Y" Grid.Row="1" Grid.Column="0" VerticalAlignment="Center"/>
                         <TextBox Text="{Binding Y, UpdateSourceTrigger=PropertyChanged, StringFormat=F0}" Grid.Row="1" Grid.Column="1"/>
                         <TextBlock Text="Max Width" Grid.Row="2" Grid.Column="0" VerticalAlignment="Center"/>
-                        <TextBox Text="{Binding MaxWidth, UpdateSourceTrigger=PropertyChanged, StringFormat=F0}" Grid.Row="2" Grid.Column="1"/>
+                        <TextBox Text="{Binding MaxWidthInput, UpdateSourceTrigger=PropertyChanged}" Grid.Row="2" Grid.Column="1"/>
                         <TextBlock Text="Max Height" Grid.Row="3" Grid.Column="0" VerticalAlignment="Center"/>
-                        <TextBox Text="{Binding MaxHeight, UpdateSourceTrigger=PropertyChanged, StringFormat=F0}" Grid.Row="3" Grid.Column="1"/>
+                        <TextBox Text="{Binding MaxHeightInput, UpdateSourceTrigger=PropertyChanged}" Grid.Row="3" Grid.Column="1"/>
                         <TextBlock Text="Rotation" Grid.Row="4" Grid.Column="0" VerticalAlignment="Center"/>
                         <TextBox Text="{Binding Rotation, UpdateSourceTrigger=PropertyChanged, StringFormat=F0}" Grid.Row="4" Grid.Column="1"/>
                         <TextBlock Text="Text" Grid.Row="5" Grid.Column="0" VerticalAlignment="Center"/>

--- a/CardCreator/Models/SelectedElementViewModel.cs
+++ b/CardCreator/Models/SelectedElementViewModel.cs
@@ -18,8 +18,46 @@ namespace CardCreator.Models {
     void SetTop(double v){ if(Element!=null){ Canvas.SetTop(Element,v); OnPropertyChanged(nameof(Y)); } }
     public double X { get=>GetLeft(); set=>SetLeft(value); }
     public double Y { get=>GetTop(); set=>SetTop(value); }
-    public double MaxWidth { get => Element?.MaxWidth ?? double.PositiveInfinity; set { if (Element != null) { Element.MaxWidth = value; if (Element is TextBlock tb) { FitToText(tb); } OnPropertyChanged(); } } }
-    public double MaxHeight { get => Element?.MaxHeight ?? double.PositiveInfinity; set { if (Element != null) { Element.MaxHeight = value; if (Element is TextBlock tb) { FitToText(tb); } OnPropertyChanged(); } } }
+    public double MaxWidth {
+      get => Element?.MaxWidth ?? double.PositiveInfinity;
+      set {
+        if (Element != null) {
+          Element.MaxWidth = value;
+          if (Element is TextBlock tb) { FitToText(tb); }
+          OnPropertyChanged();
+          OnPropertyChanged(nameof(MaxWidthInput));
+        }
+      }
+    }
+    public double MaxHeight {
+      get => Element?.MaxHeight ?? double.PositiveInfinity;
+      set {
+        if (Element != null) {
+          Element.MaxHeight = value;
+          if (Element is TextBlock tb) { FitToText(tb); }
+          OnPropertyChanged();
+          OnPropertyChanged(nameof(MaxHeightInput));
+        }
+      }
+    }
+    public string MaxWidthInput {
+      get => double.IsPositiveInfinity(MaxWidth) ? "" : MaxWidth.ToString();
+      set {
+        if (string.IsNullOrWhiteSpace(value))
+          MaxWidth = double.PositiveInfinity;
+        else if (double.TryParse(value, out var v))
+          MaxWidth = v;
+      }
+    }
+    public string MaxHeightInput {
+      get => double.IsPositiveInfinity(MaxHeight) ? "" : MaxHeight.ToString();
+      set {
+        if (string.IsNullOrWhiteSpace(value))
+          MaxHeight = double.PositiveInfinity;
+        else if (double.TryParse(value, out var v))
+          MaxHeight = v;
+      }
+    }
     public double Rotation {
       get{
         if(Element?.RenderTransform is TransformGroup tg)


### PR DESCRIPTION
## Summary
- Accept empty or numeric max size strings and reflect infinity with blank input
- Update inspector bindings to use `MaxWidthInput`/`MaxHeightInput`
- Keep control resizing by invoking FitToText when size limits change

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c22c2e9b088326b45075c81b85cbaf