### PR TITLE
Restore fit-to-text behavior and enable multiline editing

### DIFF
--- a/CardCreator/MainWindow.xaml
+++ b/CardCreator/MainWindow.xaml
@@ -99,7 +99,7 @@
                         <TextBlock Text="Rotation" Grid.Row="4" Grid.Column="0" VerticalAlignment="Center"/>
                         <TextBox Text="{Binding Rotation, UpdateSourceTrigger=PropertyChanged, StringFormat=F0}" Grid.Row="4" Grid.Column="1"/>
                         <TextBlock Text="Text" Grid.Row="5" Grid.Column="0" VerticalAlignment="Center"/>
-                        <TextBox Text="{Binding Text, UpdateSourceTrigger=PropertyChanged}" Grid.Row="5" Grid.Column="1" IsEnabled="{Binding IsText}"/>
+                        <TextBox Text="{Binding Text, UpdateSourceTrigger=PropertyChanged}" Grid.Row="5" Grid.Column="1" IsEnabled="{Binding IsText}" AcceptsReturn="True" AcceptsTab="True"/>
                         <TextBlock Text="Font Size" Grid.Row="6" Grid.Column="0" VerticalAlignment="Center"/>
                         <TextBox Text="{Binding FontSize, UpdateSourceTrigger=PropertyChanged, StringFormat=F0}" Grid.Row="6" Grid.Column="1" IsEnabled="{Binding IsText}"/>
                         <TextBlock Text="Font Style" Grid.Row="7" Grid.Column="0" VerticalAlignment="Center"/>

--- a/CardCreator/MainWindow.xaml.cs
+++ b/CardCreator/MainWindow.xaml.cs
@@ -149,7 +149,7 @@ namespace CardCreator
         public void AddText()
         {
             if (_canvas == null) return;
-            var tb = new TextBlock { Text = "Text", FontSize = 28, Foreground = Brushes.Black, RenderTransformOrigin = new Point(0.5, 0.5) };
+            var tb = new TextBlock { Text = "Text", FontSize = 28, Foreground = Brushes.Black, RenderTransformOrigin = new Point(0.5, 0.5), TextWrapping = TextWrapping.WrapWithOverflow };
             var container = CreateContainer(tb, 60, 60, 180, 60);
             _canvas.Children.Add(container); SelectSingle(container);
         }

--- a/CardCreator/Models/SelectedElementViewModel.cs
+++ b/CardCreator/Models/SelectedElementViewModel.cs
@@ -76,7 +76,7 @@ namespace CardCreator.Models {
       }
     }
     void FitToText(TextBlock tb){
-      tb.Measure(new Size(tb.MaxWidth, tb.MaxHeight));
+      tb.Measure(new Size(double.PositiveInfinity,double.PositiveInfinity));
       var size=tb.DesiredSize;
       tb.Width=size.Width; tb.Height=size.Height;
       if(tb.Parent is Grid g){ g.Width=size.Width; g.Height=size.Height; }


### PR DESCRIPTION
## Summary
- revert `FitToText` to measure with unbounded size so text blocks resize correctly
- allow added text blocks to wrap with overflow
- permit multiline and tab input in the inspector's text field

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c22e44726c83269f4a867cc2f30a9a