### PR TITLE
Refactor menus and inspector

### DIFF
--- a/CardCreator/GridSizeToBoolConverter.cs
+++ b/CardCreator/GridSizeToBoolConverter.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace CardCreator
+{
+    public class GridSizeToBoolConverter : IValueConverter
+    {
+        public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            if (value == null || parameter == null) return false;
+            return value.ToString() == parameter.ToString();
+        }
+
+        public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            if (value is bool b && b && parameter != null && int.TryParse(parameter.ToString(), out int result))
+            {
+                return result;
+            }
+            return Binding.DoNothing;
+        }
+    }
+}

--- a/CardCreator/MainWindow.xaml
+++ b/CardCreator/MainWindow.xaml
@@ -2,45 +2,72 @@
  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
  xmlns:sys="clr-namespace:System;assembly=mscorlib"
+ xmlns:local="clr-namespace:CardCreator"
  Title="Card Template Editor (Advanced)" Height="820" Width="1320"
  Background="#FFF9F9FB" KeyDown="Window_KeyDown">
+    <Window.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVis"/>
+        <local:GridSizeToBoolConverter x:Key="GridSizeToBool"/>
+    </Window.Resources>
     <Window.DataContext>
-        <local:MainViewModel xmlns:local="clr-namespace:CardCreator"/>
+        <local:MainViewModel/>
     </Window.DataContext>
     <DockPanel>
-        <ToolBar DockPanel.Dock="Top">
-            <Button Content="Add Text" Command="{Binding AddTextCommand}"/>
-            <Button Content="Add Image" Command="{Binding AddImageCommand}"/>
-            <Separator/>
-            <ToggleButton Content="Snap" IsChecked="{Binding SnapEnabled}"/>
-            <TextBlock Margin="8,0,4,0" VerticalAlignment="Center">Grid:</TextBlock>
-            <ComboBox Width="70" SelectedItem="{Binding GridSize}">
-                <sys:Int32>5</sys:Int32>
-                <sys:Int32>10</sys:Int32>
-                <sys:Int32>20</sys:Int32>
-                <sys:Int32>25</sys:Int32>
-            </ComboBox>
-            <Separator/>
-            <Button Content="Align Left" Command="{Binding AlignLeftCommand}"/>
-            <Button Content="Align Center" Command="{Binding AlignCenterCommand}"/>
-            <Button Content="Align Right" Command="{Binding AlignRightCommand}"/>
-            <Separator/>
-            <Button Content="Align Top" Command="{Binding AlignTopCommand}"/>
-            <Button Content="Align Middle" Command="{Binding AlignMiddleCommand}"/>
-            <Button Content="Align Bottom" Command="{Binding AlignBottomCommand}"/>
-            <Separator/>
-            <Button Content="Distribute H" Command="{Binding DistributeHCommand}"/>
-            <Button Content="Distribute V" Command="{Binding DistributeVCommand}"/>
-            <Separator/>
-            <Button Content="Bring Forward" Command="{Binding BringForwardCommand}"/>
-            <Button Content="Send Backward" Command="{Binding SendBackwardCommand}"/>
-            <Separator/>
-            <Button Content="Save..." Command="{Binding SaveCommand}"/>
-            <Button Content="Load..." Command="{Binding LoadCommand}"/>
-            <Button Content="Export XAML..." Command="{Binding ExportXamlCommand}"/>
-            <Separator/>
-            <TextBlock VerticalAlignment="Center" Opacity=".7">Tip: Ctrl/Shift-click to multi-select. Drag empty space to marquee-select. Arrow keys nudge (Shift=10px).</TextBlock>
-        </ToolBar>
+        <Menu DockPanel.Dock="Top">
+            <MenuItem Header="_File">
+                <MenuItem Header="_Save..." Command="{Binding SaveCommand}">
+                    <MenuItem.Icon>
+                        <TextBlock FontFamily="Segoe MDL2 Assets" Text="&#xE74E;" FontSize="16"/>
+                    </MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="_Load..." Command="{Binding LoadCommand}">
+                    <MenuItem.Icon>
+                        <TextBlock FontFamily="Segoe MDL2 Assets" Text="&#xE8E5;" FontSize="16"/>
+                    </MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="_Export XAML..." Command="{Binding ExportXamlCommand}">
+                    <MenuItem.Icon>
+                        <TextBlock FontFamily="Segoe MDL2 Assets" Text="&#xEDE1;" FontSize="16"/>
+                    </MenuItem.Icon>
+                </MenuItem>
+            </MenuItem>
+            <MenuItem Header="_Insert">
+                <MenuItem Header="Add _Text" Command="{Binding AddTextCommand}">
+                    <MenuItem.Icon>
+                        <TextBlock FontFamily="Segoe MDL2 Assets" Text="&#xE8D2;" FontSize="16"/>
+                    </MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Add _Image" Command="{Binding AddImageCommand}">
+                    <MenuItem.Icon>
+                        <TextBlock FontFamily="Segoe MDL2 Assets" Text="&#xE8B9;" FontSize="16"/>
+                    </MenuItem.Icon>
+                </MenuItem>
+            </MenuItem>
+            <MenuItem Header="_Edit">
+                <MenuItem Header="Align _Left" Command="{Binding AlignLeftCommand}"/>
+                <MenuItem Header="Align _Center" Command="{Binding AlignCenterCommand}"/>
+                <MenuItem Header="Align _Right" Command="{Binding AlignRightCommand}"/>
+                <Separator/>
+                <MenuItem Header="Align _Top" Command="{Binding AlignTopCommand}"/>
+                <MenuItem Header="Align _Middle" Command="{Binding AlignMiddleCommand}"/>
+                <MenuItem Header="Align _Bottom" Command="{Binding AlignBottomCommand}"/>
+                <Separator/>
+                <MenuItem Header="Distribute _Horizontally" Command="{Binding DistributeHCommand}"/>
+                <MenuItem Header="Distribute _Vertically" Command="{Binding DistributeVCommand}"/>
+                <Separator/>
+                <MenuItem Header="_Bring Forward" Command="{Binding BringForwardCommand}"/>
+                <MenuItem Header="_Send Backward" Command="{Binding SendBackwardCommand}"/>
+            </MenuItem>
+            <MenuItem Header="_View">
+                <MenuItem Header="_Snap" IsCheckable="True" IsChecked="{Binding SnapEnabled}"/>
+                <MenuItem Header="_Grid Size">
+                    <MenuItem Header="5" IsCheckable="True" IsChecked="{Binding GridSize, Converter={StaticResource GridSizeToBool}, ConverterParameter=5}"/>
+                    <MenuItem Header="10" IsCheckable="True" IsChecked="{Binding GridSize, Converter={StaticResource GridSizeToBool}, ConverterParameter=10}"/>
+                    <MenuItem Header="20" IsCheckable="True" IsChecked="{Binding GridSize, Converter={StaticResource GridSizeToBool}, ConverterParameter=20}"/>
+                    <MenuItem Header="25" IsCheckable="True" IsChecked="{Binding GridSize, Converter={StaticResource GridSizeToBool}, ConverterParameter=25}"/>
+                </MenuItem>
+            </MenuItem>
+        </Menu>
         <Grid>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition/>
@@ -70,60 +97,60 @@
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
-                    <Grid DataContext="{Binding Inspector}" Margin="0,12,0,0">
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                        </Grid.RowDefinitions>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="110"/>
-                            <ColumnDefinition/>
-                        </Grid.ColumnDefinitions>
-                        <TextBlock Text="X" Grid.Row="0" Grid.Column="0" VerticalAlignment="Center"/>
-                        <TextBox Text="{Binding X, UpdateSourceTrigger=PropertyChanged, StringFormat=F0}" Grid.Row="0" Grid.Column="1"/>
-                        <TextBlock Text="Y" Grid.Row="1" Grid.Column="0" VerticalAlignment="Center"/>
-                        <TextBox Text="{Binding Y, UpdateSourceTrigger=PropertyChanged, StringFormat=F0}" Grid.Row="1" Grid.Column="1"/>
-                        <TextBlock Text="Max Width" Grid.Row="2" Grid.Column="0" VerticalAlignment="Center"/>
-                        <TextBox Text="{Binding MaxWidthInput, UpdateSourceTrigger=PropertyChanged}" Grid.Row="2" Grid.Column="1"/>
-                        <TextBlock Text="Max Height" Grid.Row="3" Grid.Column="0" VerticalAlignment="Center"/>
-                        <TextBox Text="{Binding MaxHeightInput, UpdateSourceTrigger=PropertyChanged}" Grid.Row="3" Grid.Column="1"/>
-                        <TextBlock Text="Rotation" Grid.Row="4" Grid.Column="0" VerticalAlignment="Center"/>
-                        <TextBox Text="{Binding Rotation, UpdateSourceTrigger=PropertyChanged, StringFormat=F0}" Grid.Row="4" Grid.Column="1"/>
-                        <TextBlock Text="Text" Grid.Row="5" Grid.Column="0" VerticalAlignment="Center"/>
-                        <TextBox Text="{Binding Text, UpdateSourceTrigger=PropertyChanged}" Grid.Row="5" Grid.Column="1" IsEnabled="{Binding IsText}" AcceptsReturn="True" AcceptsTab="True"/>
-                        <TextBlock Text="Font Size" Grid.Row="6" Grid.Column="0" VerticalAlignment="Center"/>
-                        <TextBox Text="{Binding FontSize, UpdateSourceTrigger=PropertyChanged, StringFormat=F0}" Grid.Row="6" Grid.Column="1" IsEnabled="{Binding IsText}"/>
-                        <TextBlock Text="Font Style" Grid.Row="7" Grid.Column="0" VerticalAlignment="Center"/>
-                        <ComboBox SelectedItem="{Binding FontStyleOption, UpdateSourceTrigger=PropertyChanged}" Grid.Row="7" Grid.Column="1" IsEnabled="{Binding IsText}">
-                            <sys:String>None</sys:String>
-                            <sys:String>Italic</sys:String>
-                            <sys:String>Bold</sys:String>
-                            <sys:String>Bold Italic</sys:String>
-                        </ComboBox>
-                        <TextBlock Text="Text Align" Grid.Row="8" Grid.Column="0" VerticalAlignment="Center"/>
-                        <ComboBox SelectedItem="{Binding TextAlignment, UpdateSourceTrigger=PropertyChanged}" Grid.Row="8" Grid.Column="1" IsEnabled="{Binding IsText}">
-                            <TextAlignment>Left</TextAlignment>
-                            <TextAlignment>Center</TextAlignment>
-                            <TextAlignment>Right</TextAlignment>
-                            <TextAlignment>Justify</TextAlignment>
-                        </ComboBox>
-                        <TextBlock Text="Color (#RRGGBB)" Grid.Row="9" Grid.Column="0" VerticalAlignment="Center"/>
-                        <TextBox Text="{Binding ForegroundHex, UpdateSourceTrigger=PropertyChanged}" Grid.Row="9" Grid.Column="1" IsEnabled="{Binding IsText}"/>
-                        <TextBlock Text="Image Source" Grid.Row="10" Grid.Column="0" VerticalAlignment="Center"/>
-                        <StackPanel Orientation="Horizontal" Grid.Row="10" Grid.Column="1">
-                            <TextBox Width="200" Text="{Binding ImageSourcePath, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding IsImage}"/>
-                            <Button Content="Browse…" Click="BrowseImage_Click" IsEnabled="{Binding IsImage}" Margin="6,0,0,0"/>
+                    <StackPanel DataContext="{Binding Inspector}" Margin="0,12,0,0">
+                        <Grid>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="110"/>
+                                <ColumnDefinition/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Text="X" Grid.Row="0" Grid.Column="0" VerticalAlignment="Center"/>
+                            <TextBox Text="{Binding X, UpdateSourceTrigger=PropertyChanged, StringFormat=F0}" Grid.Row="0" Grid.Column="1"/>
+                            <TextBlock Text="Y" Grid.Row="1" Grid.Column="0" VerticalAlignment="Center"/>
+                            <TextBox Text="{Binding Y, UpdateSourceTrigger=PropertyChanged, StringFormat=F0}" Grid.Row="1" Grid.Column="1"/>
+                            <TextBlock Text="Max Width" Grid.Row="2" Grid.Column="0" VerticalAlignment="Center"/>
+                            <TextBox Text="{Binding MaxWidthInput, UpdateSourceTrigger=PropertyChanged}" Grid.Row="2" Grid.Column="1"/>
+                            <TextBlock Text="Max Height" Grid.Row="3" Grid.Column="0" VerticalAlignment="Center"/>
+                            <TextBox Text="{Binding MaxHeightInput, UpdateSourceTrigger=PropertyChanged}" Grid.Row="3" Grid.Column="1"/>
+                            <TextBlock Text="Rotation" Grid.Row="4" Grid.Column="0" VerticalAlignment="Center"/>
+                            <TextBox Text="{Binding Rotation, UpdateSourceTrigger=PropertyChanged, StringFormat=F0}" Grid.Row="4" Grid.Column="1"/>
+                        </Grid>
+                        <StackPanel Margin="0,10,0,0" Visibility="{Binding IsText, Converter={StaticResource BoolToVis}}">
+                            <TextBlock Text="Text"/>
+                            <TextBox Text="{Binding Text, UpdateSourceTrigger=PropertyChanged}" AcceptsReturn="True" AcceptsTab="True"/>
+                            <TextBlock Text="Font Size" Margin="0,6,0,0"/>
+                            <TextBox Text="{Binding FontSize, UpdateSourceTrigger=PropertyChanged, StringFormat=F0}"/>
+                            <TextBlock Text="Font Style" Margin="0,6,0,0"/>
+                            <ComboBox SelectedItem="{Binding FontStyleOption, UpdateSourceTrigger=PropertyChanged}">
+                                <sys:String>None</sys:String>
+                                <sys:String>Italic</sys:String>
+                                <sys:String>Bold</sys:String>
+                                <sys:String>Bold Italic</sys:String>
+                            </ComboBox>
+                            <TextBlock Text="Text Align" Margin="0,6,0,0"/>
+                            <ComboBox SelectedItem="{Binding TextAlignment, UpdateSourceTrigger=PropertyChanged}">
+                                <TextAlignment>Left</TextAlignment>
+                                <TextAlignment>Center</TextAlignment>
+                                <TextAlignment>Right</TextAlignment>
+                                <TextAlignment>Justify</TextAlignment>
+                            </ComboBox>
+                            <TextBlock Text="Color (#RRGGBB)" Margin="0,6,0,0"/>
+                            <TextBox Text="{Binding ForegroundHex, UpdateSourceTrigger=PropertyChanged}"/>
                         </StackPanel>
-                    </Grid>
+                        <StackPanel Margin="0,10,0,0" Visibility="{Binding IsImage, Converter={StaticResource BoolToVis}}">
+                            <TextBlock Text="Image Source"/>
+                            <StackPanel Orientation="Horizontal">
+                                <TextBox Width="200" Text="{Binding ImageSourcePath, UpdateSourceTrigger=PropertyChanged}"/>
+                                <Button Content="Browse…" Click="BrowseImage_Click" Margin="6,0,0,0"/>
+                            </StackPanel>
+                        </StackPanel>
+                    </StackPanel>
                     <Separator Margin="0,10,0,10"/>
                     <StackPanel Orientation="Horizontal">
                         <Button Content="Delete Selected" Command="{Binding DeleteSelectedCommand}" IsEnabled="{Binding HasSelection}"/>


### PR DESCRIPTION
## Summary
- replace toolbar with categorized menu items
- show TextBlock or Image inspector controls based on selection
- include VS image icons for menu items
- remove binary menu icons, using Segoe MDL2 glyphs instead

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c23c08b1e48326841da816ce70e6bc