### PR TITLE
Add dialog for customizing canvas size

### DIFF
--- a/CardCreator/CanvasSizeDialog.xaml
+++ b/CardCreator/CanvasSizeDialog.xaml
@@ -1,0 +1,32 @@
+<Window x:Class="CardCreator.CanvasSizeDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Canvas Size" SizeToContent="WidthAndHeight" WindowStartupLocation="CenterOwner">
+    <StackPanel Margin="10">
+        <ComboBox ItemsSource="{Binding Presets}" DisplayMemberPath="Name" SelectedItem="{Binding SelectedPreset}" Margin="0,0,0,10"/>
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="100"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="100"/>
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition/>
+                <RowDefinition/>
+            </Grid.RowDefinitions>
+            <TextBlock Text="Width (in)" VerticalAlignment="Center"/>
+            <TextBox Grid.Column="1" Text="{Binding WidthInch, UpdateSourceTrigger=PropertyChanged, StringFormat=F2}" Margin="4,0"/>
+            <TextBlock Grid.Column="2" Text="Width (DIP)" Margin="10,0,0,0" VerticalAlignment="Center"/>
+            <TextBox Grid.Column="3" Text="{Binding WidthDip, UpdateSourceTrigger=PropertyChanged, StringFormat=F0}" Margin="4,0"/>
+            <TextBlock Grid.Row="1" Text="Height (in)" VerticalAlignment="Center"/>
+            <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding HeightInch, UpdateSourceTrigger=PropertyChanged, StringFormat=F2}" Margin="4,0"/>
+            <TextBlock Grid.Row="1" Grid.Column="2" Text="Height (DIP)" Margin="10,0,0,0" VerticalAlignment="Center"/>
+            <TextBox Grid.Row="1" Grid.Column="3" Text="{Binding HeightDip, UpdateSourceTrigger=PropertyChanged, StringFormat=F0}" Margin="4,0"/>
+        </Grid>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+            <Button Content="OK" IsDefault="True" Width="75" Margin="0,0,8,0" Click="Ok_Click"/>
+            <Button Content="Cancel" IsCancel="True" Width="75"/>
+        </StackPanel>
+    </StackPanel>
+</Window>

--- a/CardCreator/CanvasSizeDialog.xaml.cs
+++ b/CardCreator/CanvasSizeDialog.xaml.cs
@@ -1,0 +1,87 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Windows;
+
+namespace CardCreator;
+
+public partial class CanvasSizeDialog : Window
+{
+    public CanvasSizeDialog(double widthDip, double heightDip)
+    {
+        InitializeComponent();
+        VM = new CanvasSizeViewModel(widthDip, heightDip);
+        DataContext = VM;
+    }
+
+    public CanvasSizeViewModel VM { get; }
+
+    private void Ok_Click(object sender, RoutedEventArgs e) => DialogResult = true;
+}
+
+public class CanvasSizeViewModel : INotifyPropertyChanged
+{
+    private double _widthDip;
+    private double _heightDip;
+
+    public CanvasSizeViewModel(double widthDip, double heightDip)
+    {
+        _widthDip = widthDip;
+        _heightDip = heightDip;
+        Presets = new ObservableCollection<CardSize>
+        {
+            new("Poker", 2.5, 3.5),
+            new("Bridge", 2.25, 3.5),
+            new("Tarot", 2.75, 4.75),
+            new("Jumbo", 3.5, 5)
+        };
+    }
+
+    public ObservableCollection<CardSize> Presets { get; }
+
+    private CardSize? _selectedPreset;
+    public CardSize? SelectedPreset
+    {
+        get => _selectedPreset;
+        set
+        {
+            if (_selectedPreset != value)
+            {
+                _selectedPreset = value;
+                OnPropertyChanged();
+                if (value != null)
+                {
+                    WidthInch = value.WidthInch;
+                    HeightInch = value.HeightInch;
+                }
+            }
+        }
+    }
+
+    public double WidthDip
+    {
+        get => _widthDip;
+        set { _widthDip = value; OnPropertyChanged(); OnPropertyChanged(nameof(WidthInch)); }
+    }
+    public double HeightDip
+    {
+        get => _heightDip;
+        set { _heightDip = value; OnPropertyChanged(); OnPropertyChanged(nameof(HeightInch)); }
+    }
+
+    public double WidthInch
+    {
+        get => _widthDip / 96.0;
+        set { WidthDip = value * 96.0; }
+    }
+    public double HeightInch
+    {
+        get => _heightDip / 96.0;
+        set { HeightDip = value * 96.0; }
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+    private void OnPropertyChanged([CallerMemberName] string? name = null) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+}
+
+public record CardSize(string Name, double WidthInch, double HeightInch);

--- a/CardCreator/MainWindow.xaml
+++ b/CardCreator/MainWindow.xaml
@@ -66,6 +66,7 @@
                     <MenuItem Header="20" IsCheckable="True" IsChecked="{Binding GridSize, Converter={StaticResource GridSizeToBool}, ConverterParameter=20}"/>
                     <MenuItem Header="25" IsCheckable="True" IsChecked="{Binding GridSize, Converter={StaticResource GridSizeToBool}, ConverterParameter=25}"/>
                 </MenuItem>
+                <MenuItem Header="_Card Size..." Command="{Binding ChangeCardSizeCommand}"/>
             </MenuItem>
         </Menu>
         <Grid>
@@ -75,8 +76,8 @@
             </Grid.ColumnDefinitions>
             <ScrollViewer Grid.Column="0" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" Background="#FFEFF1F4">
                 <Grid Margin="20">
-                    <Border Width="750" Height="1050" CornerRadius="24" BorderBrush="#FFCCD1D8" BorderThickness="2" Background="{StaticResource CheckerBrush}">
-                        <Canvas x:Name="CardCanvas" Background="Transparent" Focusable="True"
+                    <Border Width="{Binding CardWidth}" Height="{Binding CardHeight}" CornerRadius="24" BorderBrush="#FFCCD1D8" BorderThickness="2" Background="{StaticResource CheckerBrush}">
+                        <Canvas x:Name="CardCanvas" Width="{Binding CardWidth}" Height="{Binding CardHeight}" Background="Transparent" Focusable="True"
               MouseLeftButtonDown="CardCanvas_MouseLeftButtonDown"
               MouseMove="CardCanvas_MouseMove"
               MouseLeftButtonUp="CardCanvas_MouseLeftButtonUp">

--- a/CardCreator/Services/TemplateSerializer.cs
+++ b/CardCreator/Services/TemplateSerializer.cs
@@ -34,7 +34,7 @@ namespace CardCreator.Services {
       File.WriteAllText(path, JsonSerializer.Serialize(model, Options));
     }
 
-    public static void LoadFromJson(Canvas canvas, string path){
+    public static TemplateModel LoadFromJson(Canvas canvas, string path){
       var json=File.ReadAllText(path);
       var model=JsonSerializer.Deserialize<TemplateModel>(json,Options) ?? new TemplateModel();
       canvas.Children.Clear();
@@ -63,6 +63,7 @@ namespace CardCreator.Services {
         Canvas.SetLeft(container,item.X); Canvas.SetTop(container,item.Y);
         canvas.Children.Add(container);
       }
+      return model;
     }
 
     public static void ExportToXaml(Canvas canvas, string path, double cardW, double cardH){


### PR DESCRIPTION
## Summary
- add dialog to adjust canvas width and height using inches and device units with common card presets
- bind card canvas and saving/exporting to configurable card size

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c24eb6e1f083269013a32c2d46dea7