### PR TITLE
Add visibility control, font family picker, and template persistence

### DIFF
--- a/CardCreator/MainWindow.xaml
+++ b/CardCreator/MainWindow.xaml
@@ -101,16 +101,31 @@
                     <Grid DataContext="{Binding Inspector}" Margin="0,12,0,0">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto"/>
+                        <!--0-->
                             <RowDefinition Height="Auto"/>
+                        <!--1-->
                             <RowDefinition Height="Auto"/>
+                        <!--2-->
                             <RowDefinition Height="Auto"/>
+                        <!--3-->
                             <RowDefinition Height="Auto"/>
+                        <!--4-->
                             <RowDefinition Height="Auto"/>
+                        <!--5-->
                             <RowDefinition Height="Auto"/>
+                        <!--6-->
                             <RowDefinition Height="Auto"/>
+                        <!--7 FontFamily-->
                             <RowDefinition Height="Auto"/>
+                        <!--8 FontStyle-->
                             <RowDefinition Height="Auto"/>
+                        <!--9 TextAlign-->
                             <RowDefinition Height="Auto"/>
+                        <!--10 Color-->
+                            <RowDefinition Height="Auto"/>
+                        <!--11 ImageSource-->
+                            <RowDefinition Height="Auto"/>
+                        <!--12 Hidden-->
                         </Grid.RowDefinitions>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="110"/>
@@ -130,24 +145,26 @@
                         <TextBox Text="{Binding Text, UpdateSourceTrigger=PropertyChanged}" Grid.Row="5" Grid.Column="1" IsEnabled="{Binding IsText}" AcceptsReturn="True"/>
                         <TextBlock Text="Font Size" Grid.Row="6" Grid.Column="0" VerticalAlignment="Center"/>
                         <TextBox Text="{Binding FontSize, UpdateSourceTrigger=PropertyChanged, StringFormat=F0}" Grid.Row="6" Grid.Column="1" IsEnabled="{Binding IsText}"/>
-                        <TextBlock Text="Font Style" Grid.Row="7" Grid.Column="0" VerticalAlignment="Center"/>
-                        <ComboBox SelectedItem="{Binding FontStyleOption, UpdateSourceTrigger=PropertyChanged}" Grid.Row="7" Grid.Column="1" IsEnabled="{Binding IsText}">
+                        <TextBlock Text="Font Family" Grid.Row="7" Grid.Column="0" VerticalAlignment="Center"/>
+                        <ComboBox ItemsSource="{Binding FontFamilies}" SelectedItem="{Binding FontFamily, UpdateSourceTrigger=PropertyChanged}" Grid.Row="7" Grid.Column="1" IsEnabled="{Binding IsText}" DisplayMemberPath="Source"/>
+                        <TextBlock Text="Font Style" Grid.Row="8" Grid.Column="0" VerticalAlignment="Center"/>
+                        <ComboBox SelectedItem="{Binding FontStyleOption, UpdateSourceTrigger=PropertyChanged}" Grid.Row="8" Grid.Column="1" IsEnabled="{Binding IsText}">
                             <sys:String>None</sys:String>
                             <sys:String>Italic</sys:String>
                             <sys:String>Bold</sys:String>
                             <sys:String>Bold Italic</sys:String>
                         </ComboBox>
-                        <TextBlock Text="Text Align" Grid.Row="8" Grid.Column="0" VerticalAlignment="Center"/>
-                        <ComboBox SelectedItem="{Binding TextAlignment, UpdateSourceTrigger=PropertyChanged}" Grid.Row="8" Grid.Column="1" IsEnabled="{Binding IsText}">
+                        <TextBlock Text="Text Align" Grid.Row="9" Grid.Column="0" VerticalAlignment="Center"/>
+                        <ComboBox SelectedItem="{Binding TextAlignment, UpdateSourceTrigger=PropertyChanged}" Grid.Row="9" Grid.Column="1" IsEnabled="{Binding IsText}">
                             <TextAlignment>Left</TextAlignment>
                             <TextAlignment>Center</TextAlignment>
                             <TextAlignment>Right</TextAlignment>
                             <TextAlignment>Justify</TextAlignment>
                         </ComboBox>
-                        <TextBlock Text="Color (#RRGGBB)" Grid.Row="9" Grid.Column="0" VerticalAlignment="Center"/>
-                        <TextBox Text="{Binding ForegroundHex, UpdateSourceTrigger=PropertyChanged}" Grid.Row="9" Grid.Column="1" IsEnabled="{Binding IsText}"/>
-                        <TextBlock Text="Image Source" Grid.Row="10" Grid.Column="0" VerticalAlignment="Center"/>
-                        <StackPanel Orientation="Horizontal" Grid.Row="10" Grid.Column="1">
+                        <TextBlock Text="Color (#RRGGBB)" Grid.Row="10" Grid.Column="0" VerticalAlignment="Center"/>
+                        <TextBox Text="{Binding ForegroundHex, UpdateSourceTrigger=PropertyChanged}" Grid.Row="10" Grid.Column="1" IsEnabled="{Binding IsText}"/>
+                        <TextBlock Text="Image Source" Grid.Row="11" Grid.Column="0" VerticalAlignment="Center"/>
+                        <StackPanel Orientation="Horizontal" Grid.Row="11" Grid.Column="1">
                             <TextBox Width="200" Text="{Binding ImageSourcePath, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding IsImage}"/>
                             <Button Content="Browse…" Click="BrowseImage_Click" IsEnabled="{Binding IsImage}" Margin="6,0,0,0"/>
                         </StackPanel>
@@ -158,6 +175,8 @@
                                 <Button Content="Browse…" Click="BrowseImage_Click" Margin="6,0,0,0"/>
                             </StackPanel>
                         </StackPanel>
+                        <TextBlock Text="Hidden" Grid.Row="12" Grid.Column="0" VerticalAlignment="Center"/>
+                        <CheckBox IsChecked="{Binding IsHidden, UpdateSourceTrigger=PropertyChanged}" Grid.Row="12" Grid.Column="1" IsEnabled="{Binding Element, Converter={StaticResource NullToBoolInverse}}"/>
                     </Grid>
                     <Separator Margin="0,10,0,10"/>
                     <StackPanel Orientation="Horizontal">

--- a/CardCreator/MainWindow.xaml.cs
+++ b/CardCreator/MainWindow.xaml.cs
@@ -163,6 +163,7 @@ namespace CardCreator
             if (_canvas == null) return;
             var img = new Image { Stretch = Stretch.Uniform, RenderTransformOrigin = new Point(0.5, 0.5) };
             var container = CreateContainer(img, 100, 100, 200, 140);
+            container.Background = Brushes.White;
             _canvas.Children.Add(container); SelectSingle(container);
         }
 

--- a/CardCreator/Models/SelectedElementViewModel.cs
+++ b/CardCreator/Models/SelectedElementViewModel.cs
@@ -2,6 +2,8 @@ using System;
 using System.ComponentModel;
 using System.Globalization;
 using System.Runtime.CompilerServices;
+using System.Collections.Generic;
+using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
@@ -110,6 +112,13 @@ namespace CardCreator.Models {
         }
     public string Text { get=> (Element as TextBlock)?.Text ?? ""; set{ if(Element is TextBlock tb){ tb.Text=value; FitToText(tb); OnPropertyChanged(); } } }
     public double FontSize { get=> (Element as TextBlock)?.FontSize ?? 16; set{ if(Element is TextBlock tb){ tb.FontSize=value; FitToText(tb); OnPropertyChanged(); } } }
+
+    public IEnumerable<FontFamily> FontFamilies { get; } = Fonts.SystemFontFamilies.OrderBy(f => f.Source);
+    public FontFamily FontFamily {
+      get => (Element as TextBlock)?.FontFamily ?? Fonts.SystemFontFamilies.First();
+      set { if (Element is TextBlock tb) { tb.FontFamily = value; FitToText(tb); OnPropertyChanged(); } }
+    }
+
     public string FontStyleOption {
       get {
         if (Element is TextBlock tb) {
@@ -158,6 +167,19 @@ namespace CardCreator.Models {
           try{ tb.Foreground=new SolidColorBrush((Color)ColorConverter.ConvertFromString(value)); }catch{}
           OnPropertyChanged();
         }
+      }
+    }
+    public bool IsHidden {
+      get {
+        if (Element == null) return false;
+        return Element.Visibility != Visibility.Visible;
+      }
+      set {
+        if (Element == null) return;
+        Element.Visibility = value ? Visibility.Hidden : Visibility.Visible;
+        if (Element.Parent is Grid g && Element is Image)
+          g.Background = value ? Brushes.Transparent : Brushes.White;
+        OnPropertyChanged();
       }
     }
     public string ImageSourcePath {

--- a/CardCreator/Models/TemplateModel.cs
+++ b/CardCreator/Models/TemplateModel.cs
@@ -16,8 +16,12 @@ namespace CardCreator.Models {
     public string? Text {get;set;}
     public double? FontSize {get;set;}
     public bool? Bold {get;set;}
+    public bool? Italic {get;set;}
+    public string? FontFamily {get;set;}
+    public string? TextAlignment {get;set;}
     public string? ForegroundHex {get;set;}
     public string? Source {get;set;}
     public string? Stretch {get;set;}
+    public bool? Hidden {get;set;}
   }
 }

--- a/CardCreator/Services/TemplateSerializer.cs
+++ b/CardCreator/Services/TemplateSerializer.cs
@@ -21,10 +21,13 @@ namespace CardCreator.Services {
         if(obj is not Grid g || g.Children.Count==0) continue;
         var inner=(FrameworkElement)g.Children[0];
         var item=new TemplateItem{
-          X=Canvas.GetLeft(g), Y=Canvas.GetTop(g), Width=g.Width, Height=g.Height, Rotation=GetRotation(inner), Z=z++
+          X=Canvas.GetLeft(g), Y=Canvas.GetTop(g), Width=g.Width, Height=g.Height, Rotation=GetRotation(inner), Z=z++,
+          Hidden=inner.Visibility!=Visibility.Visible
         };
         if(inner is TextBlock tb){
           item.Type="Text"; item.Text=tb.Text; item.FontSize=tb.FontSize; item.Bold=tb.FontWeight==FontWeights.Bold;
+          item.Italic=tb.FontStyle==FontStyles.Italic; item.TextAlignment=tb.TextAlignment.ToString();
+          item.FontFamily=tb.FontFamily.Source;
           if(tb.Foreground is SolidColorBrush scb) item.ForegroundHex=$"#{scb.Color.R:X2}{scb.Color.G:X2}{scb.Color.B:X2}";
         } else if(inner is Image img){
           item.Type="Image"; item.Source=TryGetImageSource(img); item.Stretch=img.Stretch.ToString();
@@ -49,16 +52,21 @@ namespace CardCreator.Services {
               img.Source=bi;
             }catch{}
           }
+          if(item.Hidden==true) img.Visibility=Visibility.Hidden;
           inner=img;
         } else {
           var tb=new TextBlock{ Text=item.Text??"Text", FontSize=item.FontSize??28 };
           if(item.Bold==true) tb.FontWeight=FontWeights.Bold;
+          if(item.Italic==true) tb.FontStyle=FontStyles.Italic;
+          if(!string.IsNullOrWhiteSpace(item.FontFamily)) try{ tb.FontFamily=new FontFamily(item.FontFamily); }catch{}
+          if(!string.IsNullOrWhiteSpace(item.TextAlignment) && Enum.TryParse<TextAlignment>(item.TextAlignment, out var ta)) tb.TextAlignment=ta;
           if(!string.IsNullOrWhiteSpace(item.ForegroundHex)){ try{ tb.Foreground=new SolidColorBrush((Color)ColorConverter.ConvertFromString(item.ForegroundHex!)); }catch{} }
+          if(item.Hidden==true) tb.Visibility=Visibility.Hidden;
           inner=tb;
         }
         inner.RenderTransformOrigin=new Point(0.5,0.5);
         ApplyRotation(inner, item.Rotation);
-        var container=new Grid{ Background=Brushes.Transparent, Width=item.Width, Height=item.Height };
+        var container=new Grid{ Background=item.Type=="Image"? (item.Hidden==true?Brushes.Transparent:Brushes.White) : Brushes.Transparent, Width=item.Width, Height=item.Height };
         container.Children.Add(inner);
         Canvas.SetLeft(container,item.X); Canvas.SetTop(container,item.Y);
         canvas.Children.Add(container);
@@ -76,14 +84,25 @@ namespace CardCreator.Services {
         if(inner is TextBlock tb){
           string color="#000000";
           if(tb.Foreground is SolidColorBrush scb) color=$"#{scb.Color.R:X2}{scb.Color.G:X2}{scb.Color.B:X2}";
-          sb.AppendLine("  <TextBlock Text=\""+XmlEscape(tb.Text)+"\" FontSize=\""+tb.FontSize+"\" FontWeight=\""+(tb.FontWeight==FontWeights.Bold?"Bold":"Normal")+"\" Foreground=\""+color+"\" Width=\""+g.Width+"\" Height=\""+g.Height+"\" Canvas.Left=\""+x+"\" Canvas.Top=\""+y+"\">"); 
+          var attrs=" Text=\""+XmlEscape(tb.Text)+"\""+
+            " FontSize=\""+tb.FontSize+"\""+
+            " FontFamily=\""+XmlEscape(tb.FontFamily.Source)+"\""+
+            " FontWeight=\""+(tb.FontWeight==FontWeights.Bold?"Bold":"Normal")+"\""+
+            " FontStyle=\""+(tb.FontStyle==FontStyles.Italic?"Italic":"Normal")+"\""+
+            " TextAlignment=\""+tb.TextAlignment+"\""+
+            " Foreground=\""+color+"\""+
+            " Width=\""+g.Width+"\" Height=\""+g.Height+"\" Canvas.Left=\""+x+"\" Canvas.Top=\""+y+"\"";
+          if(tb.Visibility!=Visibility.Visible) attrs+=" Visibility=\""+tb.Visibility+"\"";
+          sb.AppendLine("  <TextBlock"+attrs+">");
           var angle=GetRotation(inner);
           if(Math.Abs(angle)>0.001) sb.AppendLine("    <TextBlock.RenderTransform><RotateTransform Angle=\""+angle+"\"/></TextBlock.RenderTransform>");
           sb.AppendLine("  </TextBlock>");
         } else if(inner is Image img){
           string srcAttr="";
           if(img.Source is BitmapImage bi && bi.UriSource!=null) srcAttr=" Source=\""+XmlEscape(bi.UriSource.ToString())+"\"";
-          sb.AppendLine("  <Image"+srcAttr+" Stretch=\""+img.Stretch+"\" Width=\""+g.Width+"\" Height=\""+g.Height+"\" Canvas.Left=\""+x+"\" Canvas.Top=\""+y+"\">"); 
+          var attrs=srcAttr+" Stretch=\""+img.Stretch+"\" Width=\""+g.Width+"\" Height=\""+g.Height+"\" Canvas.Left=\""+x+"\" Canvas.Top=\""+y+"\"";
+          if(img.Visibility!=Visibility.Visible) attrs+=" Visibility=\""+img.Visibility+"\"";
+          sb.AppendLine("  <Image"+attrs+">");
           var angle=GetRotation(inner);
           if(Math.Abs(angle)>0.001) sb.AppendLine("    <Image.RenderTransform><RotateTransform Angle=\""+angle+"\"/></Image.RenderTransform>");
           sb.AppendLine("  </Image>");


### PR DESCRIPTION
## Summary
- Add inspector controls to hide elements and choose text font family
- Default new images to a white background for easier visibility
- Persist visibility, font family, style, and alignment when saving templates

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c26340a1dc832691b402cd243d1981