### PR TITLE
Organize inspector controls and streamline deletion

### DIFF
--- a/CardCreator/MainWindow.xaml
+++ b/CardCreator/MainWindow.xaml
@@ -60,6 +60,7 @@
             </MenuItem>
             <MenuItem Header="_View">
                 <MenuItem Header="_Snap" IsCheckable="True" IsChecked="{Binding SnapEnabled}"/>
+                <MenuItem Header="Show _Guidelines" IsCheckable="True" IsChecked="{Binding GuidelinesEnabled}"/>
                 <MenuItem Header="_Grid Size">
                     <MenuItem Header="5" IsCheckable="True" IsChecked="{Binding GridSize, Converter={StaticResource GridSizeToBool}, ConverterParameter=5}"/>
                     <MenuItem Header="10" IsCheckable="True" IsChecked="{Binding GridSize, Converter={StaticResource GridSizeToBool}, ConverterParameter=10}"/>
@@ -94,94 +95,97 @@
                     <ItemsControl ItemsSource="{Binding SelectedItems}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <TextBlock Text="{Binding Name}"/>
+                                <TextBlock Text="{Binding Tag}"/>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
-                    <Grid DataContext="{Binding Inspector}" Margin="0,12,0,0">
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto"/>
-                        <!--0-->
-                            <RowDefinition Height="Auto"/>
-                        <!--1-->
-                            <RowDefinition Height="Auto"/>
-                        <!--2-->
-                            <RowDefinition Height="Auto"/>
-                        <!--3-->
-                            <RowDefinition Height="Auto"/>
-                        <!--4-->
-                            <RowDefinition Height="Auto"/>
-                        <!--5-->
-                            <RowDefinition Height="Auto"/>
-                        <!--6-->
-                            <RowDefinition Height="Auto"/>
-                        <!--7 FontFamily-->
-                            <RowDefinition Height="Auto"/>
-                        <!--8 FontStyle-->
-                            <RowDefinition Height="Auto"/>
-                        <!--9 TextAlign-->
-                            <RowDefinition Height="Auto"/>
-                        <!--10 Color-->
-                            <RowDefinition Height="Auto"/>
-                        <!--11 ImageSource-->
-                            <RowDefinition Height="Auto"/>
-                        <!--12 Hidden-->
-                        </Grid.RowDefinitions>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="110"/>
-                            <ColumnDefinition/>
-                        </Grid.ColumnDefinitions>
-                        <TextBlock Text="X" Grid.Row="0" Grid.Column="0" VerticalAlignment="Center"/>
-                        <TextBox Text="{Binding X, UpdateSourceTrigger=PropertyChanged, StringFormat=F0}" Grid.Row="0" Grid.Column="1"/>
-                        <TextBlock Text="Y" Grid.Row="1" Grid.Column="0" VerticalAlignment="Center"/>
-                        <TextBox Text="{Binding Y, UpdateSourceTrigger=PropertyChanged, StringFormat=F0}" Grid.Row="1" Grid.Column="1"/>
-                        <TextBlock Text="Width" Grid.Row="2" Grid.Column="0" VerticalAlignment="Center"/>
-                        <TextBox Text="{Binding WidthInput, UpdateSourceTrigger=PropertyChanged}" Grid.Row="2" Grid.Column="1"/>
-                        <TextBlock Text="Height" Grid.Row="3" Grid.Column="0" VerticalAlignment="Center"/>
-                        <TextBox Text="{Binding HeightInput, UpdateSourceTrigger=PropertyChanged}" Grid.Row="3" Grid.Column="1"/>
-                        <TextBlock Text="Rotation" Grid.Row="4" Grid.Column="0" VerticalAlignment="Center"/>
-                        <TextBox Text="{Binding Rotation, UpdateSourceTrigger=PropertyChanged, StringFormat=F0}" Grid.Row="4" Grid.Column="1"/>
-                        <TextBlock Text="Text" Grid.Row="5" Grid.Column="0" VerticalAlignment="Center"/>
-                        <TextBox Text="{Binding Text, UpdateSourceTrigger=PropertyChanged}" Grid.Row="5" Grid.Column="1" IsEnabled="{Binding IsText}" AcceptsReturn="True"/>
-                        <TextBlock Text="Font Size" Grid.Row="6" Grid.Column="0" VerticalAlignment="Center"/>
-                        <TextBox Text="{Binding FontSize, UpdateSourceTrigger=PropertyChanged, StringFormat=F0}" Grid.Row="6" Grid.Column="1" IsEnabled="{Binding IsText}"/>
-                        <TextBlock Text="Font Family" Grid.Row="7" Grid.Column="0" VerticalAlignment="Center"/>
-                        <ComboBox ItemsSource="{Binding FontFamilies}" SelectedItem="{Binding FontFamily, UpdateSourceTrigger=PropertyChanged}" Grid.Row="7" Grid.Column="1" IsEnabled="{Binding IsText}" DisplayMemberPath="Source"/>
-                        <TextBlock Text="Font Style" Grid.Row="8" Grid.Column="0" VerticalAlignment="Center"/>
-                        <ComboBox SelectedItem="{Binding FontStyleOption, UpdateSourceTrigger=PropertyChanged}" Grid.Row="8" Grid.Column="1" IsEnabled="{Binding IsText}">
-                            <sys:String>None</sys:String>
-                            <sys:String>Italic</sys:String>
-                            <sys:String>Bold</sys:String>
-                            <sys:String>Bold Italic</sys:String>
-                        </ComboBox>
-                        <TextBlock Text="Text Align" Grid.Row="9" Grid.Column="0" VerticalAlignment="Center"/>
-                        <ComboBox SelectedItem="{Binding TextAlignment, UpdateSourceTrigger=PropertyChanged}" Grid.Row="9" Grid.Column="1" IsEnabled="{Binding IsText}">
-                            <TextAlignment>Left</TextAlignment>
-                            <TextAlignment>Center</TextAlignment>
-                            <TextAlignment>Right</TextAlignment>
-                            <TextAlignment>Justify</TextAlignment>
-                        </ComboBox>
-                        <TextBlock Text="Color (#RRGGBB)" Grid.Row="10" Grid.Column="0" VerticalAlignment="Center"/>
-                        <TextBox Text="{Binding ForegroundHex, UpdateSourceTrigger=PropertyChanged}" Grid.Row="10" Grid.Column="1" IsEnabled="{Binding IsText}"/>
-                        <TextBlock Text="Image Source" Grid.Row="11" Grid.Column="0" VerticalAlignment="Center"/>
-                        <StackPanel Orientation="Horizontal" Grid.Row="11" Grid.Column="1">
-                            <TextBox Width="200" Text="{Binding ImageSourcePath, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding IsImage}"/>
-                            <Button Content="Browse…" Click="BrowseImage_Click" IsEnabled="{Binding IsImage}" Margin="6,0,0,0"/>
-                        </StackPanel>
-                        <StackPanel Margin="0,10,0,0" Visibility="{Binding IsImage, Converter={StaticResource BoolToVis}}">
-                            <TextBlock Text="Image Source"/>
-                            <StackPanel Orientation="Horizontal">
+                    <StackPanel DataContext="{Binding Inspector}" Margin="0,12,0,0">
+                        <Grid>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                <!--0-->
+                                <RowDefinition Height="Auto"/>
+                <!--1-->
+                                <RowDefinition Height="Auto"/>
+                <!--2-->
+                                <RowDefinition Height="Auto"/>
+                <!--3-->
+                                <RowDefinition Height="Auto"/>
+                <!--4-->
+                                <RowDefinition Height="Auto"/>
+                <!--5-->
+                                <RowDefinition Height="Auto"/>
+                <!--6-->
+                            </Grid.RowDefinitions>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="110"/>
+                                <ColumnDefinition/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Text="Label" Grid.Row="0" Grid.Column="0" VerticalAlignment="Center"/>
+                            <TextBox Text="{Binding Label, UpdateSourceTrigger=PropertyChanged}" Grid.Row="0" Grid.Column="1"/>
+                            <TextBlock Text="X" Grid.Row="1" Grid.Column="0" VerticalAlignment="Center"/>
+                            <TextBox Text="{Binding X, UpdateSourceTrigger=PropertyChanged, StringFormat=F0}" Grid.Row="1" Grid.Column="1"/>
+                            <TextBlock Text="Y" Grid.Row="2" Grid.Column="0" VerticalAlignment="Center"/>
+                            <TextBox Text="{Binding Y, UpdateSourceTrigger=PropertyChanged, StringFormat=F0}" Grid.Row="2" Grid.Column="1"/>
+                            <TextBlock Text="Width" Grid.Row="3" Grid.Column="0" VerticalAlignment="Center"/>
+                            <TextBox Text="{Binding WidthInput, UpdateSourceTrigger=PropertyChanged}" Grid.Row="3" Grid.Column="1"/>
+                            <TextBlock Text="Height" Grid.Row="4" Grid.Column="0" VerticalAlignment="Center"/>
+                            <TextBox Text="{Binding HeightInput, UpdateSourceTrigger=PropertyChanged}" Grid.Row="4" Grid.Column="1"/>
+                            <TextBlock Text="Rotation" Grid.Row="5" Grid.Column="0" VerticalAlignment="Center"/>
+                            <TextBox Text="{Binding Rotation, UpdateSourceTrigger=PropertyChanged, StringFormat=F0}" Grid.Row="5" Grid.Column="1"/>
+                            <TextBlock Text="Hidden" Grid.Row="6" Grid.Column="0" VerticalAlignment="Center"/>
+                            <CheckBox IsChecked="{Binding IsHidden, UpdateSourceTrigger=PropertyChanged}" Grid.Row="6" Grid.Column="1" IsEnabled="{Binding Element, Converter={StaticResource NullToBoolInverse}}"/>
+                        </Grid>
+                        <Grid Visibility="{Binding IsText, Converter={StaticResource BoolToVis}}" Margin="0,10,0,0">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="110"/>
+                                <ColumnDefinition/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Text="Text" Grid.Row="0" Grid.Column="0" VerticalAlignment="Center"/>
+                            <TextBox Text="{Binding Text, UpdateSourceTrigger=PropertyChanged}" Grid.Row="0" Grid.Column="1" AcceptsReturn="True"/>
+                            <TextBlock Text="Font Size" Grid.Row="1" Grid.Column="0" VerticalAlignment="Center"/>
+                            <TextBox Text="{Binding FontSize, UpdateSourceTrigger=PropertyChanged, StringFormat=F0}" Grid.Row="1" Grid.Column="1"/>
+                            <TextBlock Text="Font Family" Grid.Row="2" Grid.Column="0" VerticalAlignment="Center"/>
+                            <ComboBox ItemsSource="{Binding FontFamilies}" SelectedItem="{Binding FontFamily, UpdateSourceTrigger=PropertyChanged}" Grid.Row="2" Grid.Column="1" DisplayMemberPath="Source"/>
+                            <TextBlock Text="Font Style" Grid.Row="3" Grid.Column="0" VerticalAlignment="Center"/>
+                            <ComboBox SelectedItem="{Binding FontStyleOption, UpdateSourceTrigger=PropertyChanged}" Grid.Row="3" Grid.Column="1">
+                                <sys:String>None</sys:String>
+                                <sys:String>Italic</sys:String>
+                                <sys:String>Bold</sys:String>
+                                <sys:String>Bold Italic</sys:String>
+                            </ComboBox>
+                            <TextBlock Text="Text Align" Grid.Row="4" Grid.Column="0" VerticalAlignment="Center"/>
+                            <ComboBox SelectedItem="{Binding TextAlignment, UpdateSourceTrigger=PropertyChanged}" Grid.Row="4" Grid.Column="1">
+                                <TextAlignment>Left</TextAlignment>
+                                <TextAlignment>Center</TextAlignment>
+                                <TextAlignment>Right</TextAlignment>
+                                <TextAlignment>Justify</TextAlignment>
+                            </ComboBox>
+                            <TextBlock Text="Color (#RRGGBB)" Grid.Row="5" Grid.Column="0" VerticalAlignment="Center"/>
+                            <TextBox Text="{Binding ForegroundHex, UpdateSourceTrigger=PropertyChanged}" Grid.Row="5" Grid.Column="1"/>
+                        </Grid>
+                        <Grid Visibility="{Binding IsImage, Converter={StaticResource BoolToVis}}" Margin="0,10,0,0">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="110"/>
+                                <ColumnDefinition/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Text="Image Source" Grid.Row="0" Grid.Column="0" VerticalAlignment="Center"/>
+                            <StackPanel Orientation="Horizontal" Grid.Row="0" Grid.Column="1">
                                 <TextBox Width="200" Text="{Binding ImageSourcePath, UpdateSourceTrigger=PropertyChanged}"/>
                                 <Button Content="Browse…" Click="BrowseImage_Click" Margin="6,0,0,0"/>
                             </StackPanel>
-                        </StackPanel>
-                        <TextBlock Text="Hidden" Grid.Row="12" Grid.Column="0" VerticalAlignment="Center"/>
-                        <CheckBox IsChecked="{Binding IsHidden, UpdateSourceTrigger=PropertyChanged}" Grid.Row="12" Grid.Column="1" IsEnabled="{Binding Element, Converter={StaticResource NullToBoolInverse}}"/>
-                    </Grid>
-                    <Separator Margin="0,10,0,10"/>
-                    <StackPanel Orientation="Horizontal">
-                        <Button Content="Delete Selected" Command="{Binding DeleteSelectedCommand}" IsEnabled="{Binding HasSelection}"/>
-                        <CheckBox Content="Show Guidelines" IsChecked="{Binding GuidelinesEnabled}" Margin="10,0,0,0"/>
+                        </Grid>
                     </StackPanel>
                 </StackPanel>
             </Border>

--- a/CardCreator/MainWindow.xaml.cs
+++ b/CardCreator/MainWindow.xaml.cs
@@ -33,7 +33,6 @@ namespace CardCreator
 
         public RelayCommand AddTextCommand { get; }
         public RelayCommand AddImageCommand { get; }
-        public RelayCommand DeleteSelectedCommand { get; }
         public RelayCommand SaveCommand { get; }
         public RelayCommand LoadCommand { get; }
         public RelayCommand ExportXamlCommand { get; }
@@ -65,7 +64,6 @@ namespace CardCreator
         {
             AddTextCommand = new RelayCommand(_ => AddText());
             AddImageCommand = new RelayCommand(_ => AddImage());
-            DeleteSelectedCommand = new RelayCommand(_ => DeleteSelected(), _ => HasSelection);
             SaveCommand = new RelayCommand(_ => Save());
             LoadCommand = new RelayCommand(_ => Load());
             ExportXamlCommand = new RelayCommand(_ => ExportXaml());
@@ -115,6 +113,8 @@ namespace CardCreator
                 if (SnapEnabled) { nx = Snap(nx); ny = Snap(ny); }
                 Canvas.SetLeft(_draggingContainer, Math.Max(0, nx)); Canvas.SetTop(_draggingContainer, Math.Max(0, ny));
                 if (GuidelinesEnabled) UpdateGuidelines(_draggingContainer);
+                if (_selected.Count == 1 && _selected[0] == _draggingContainer)
+                    Inspector.RefreshPosition();
             }
         }
 
@@ -129,6 +129,12 @@ namespace CardCreator
         public void OnKeyDown(KeyEventArgs e)
         {
             if (_canvas == null || _selected.Count == 0) return;
+            if (e.Key == Key.Delete)
+            {
+                DeleteSelected();
+                e.Handled = true;
+                return;
+            }
             int step = (Keyboard.IsKeyDown(Key.LeftShift) || Keyboard.IsKeyDown(Key.RightShift)) ? 10 : 1;
             bool handled = false;
             foreach (var c in _selected)
@@ -183,7 +189,6 @@ namespace CardCreator
         {
             _selected.Clear(); UpdateSelectionVisuals(); Inspector.SetElement(null);
             OnPropertyChanged(nameof(HasSelection));
-            DeleteSelectedCommand.RaiseCanExecuteChanged();
             AlignLeftCommand.RaiseCanExecuteChanged(); AlignCenterCommand.RaiseCanExecuteChanged(); AlignRightCommand.RaiseCanExecuteChanged();
             AlignTopCommand.RaiseCanExecuteChanged(); AlignMiddleCommand.RaiseCanExecuteChanged(); AlignBottomCommand.RaiseCanExecuteChanged();
             DistributeHCommand.RaiseCanExecuteChanged(); DistributeVCommand.RaiseCanExecuteChanged();
@@ -197,7 +202,6 @@ namespace CardCreator
                 if (child.Children.Count >= 2 && child.Children[1] is Border b) b.Visibility = _selected.Contains(child) ? Visibility.Visible : Visibility.Collapsed;
             }
             OnPropertyChanged(nameof(SelectedItems)); OnPropertyChanged(nameof(HasSelection));
-            DeleteSelectedCommand.RaiseCanExecuteChanged();
             AlignLeftCommand.RaiseCanExecuteChanged(); AlignCenterCommand.RaiseCanExecuteChanged(); AlignRightCommand.RaiseCanExecuteChanged();
             AlignTopCommand.RaiseCanExecuteChanged(); AlignMiddleCommand.RaiseCanExecuteChanged(); AlignBottomCommand.RaiseCanExecuteChanged();
             DistributeHCommand.RaiseCanExecuteChanged(); DistributeVCommand.RaiseCanExecuteChanged();

--- a/CardCreator/Models/SelectedElementViewModel.cs
+++ b/CardCreator/Models/SelectedElementViewModel.cs
@@ -11,14 +11,26 @@ using System.Windows.Media;
 namespace CardCreator.Models {
   public class SelectedElementViewModel : INotifyPropertyChanged {
     public FrameworkElement? Element {get; private set;}
+    public FrameworkElement? Container {get; private set;}
     public string? ElementType {get; private set;}
     public bool IsText => Element is TextBlock;
     public bool IsImage => Element is Image;
-    public void SetElement(FrameworkElement? element){ Element=element; ElementType=element?.GetType().Name; OnPropertyChanged(string.Empty); }
-    double GetLeft()=> Element!=null? Canvas.GetLeft(Element):0;
-    void SetLeft(double v){ if(Element!=null){ Canvas.SetLeft(Element,v); OnPropertyChanged(nameof(X)); } }
-    double GetTop()=> Element!=null? Canvas.GetTop(Element):0;
-    void SetTop(double v){ if(Element!=null){ Canvas.SetTop(Element,v); OnPropertyChanged(nameof(Y)); } }
+    public void SetElement(FrameworkElement? element){ Element=element; Container=element?.Parent as FrameworkElement; ElementType=element?.GetType().Name; OnPropertyChanged(string.Empty); }
+    public string Label {
+      get => Element?.Tag as string ?? "";
+      set {
+        if (Element != null) {
+          Element.Tag = value;
+          if (Container != null) Container.Tag = value;
+          OnPropertyChanged();
+        }
+      }
+    }
+    double GetLeft()=> Container!=null? Canvas.GetLeft(Container):0;
+    void SetLeft(double v){ if(Container!=null){ Canvas.SetLeft(Container,v); OnPropertyChanged(nameof(X)); } }
+    double GetTop()=> Container!=null? Canvas.GetTop(Container):0;
+    void SetTop(double v){ if(Container!=null){ Canvas.SetTop(Container,v); OnPropertyChanged(nameof(Y)); } }
+    public void RefreshPosition(){ OnPropertyChanged(nameof(X)); OnPropertyChanged(nameof(Y)); }
     public double X { get=>GetLeft(); set=>SetLeft(value); }
     public double Y { get=>GetTop(); set=>SetTop(value); }
     public double Width {

--- a/CardCreator/Models/TemplateModel.cs
+++ b/CardCreator/Models/TemplateModel.cs
@@ -13,6 +13,7 @@ namespace CardCreator.Models {
     public double Height {get;set;}
     public double Rotation {get;set;}
     public int Z {get;set;}
+    public string? Label {get;set;}
     public string? Text {get;set;}
     public double? FontSize {get;set;}
     public bool? Bold {get;set;}

--- a/CardCreator/Services/TemplateSerializer.cs
+++ b/CardCreator/Services/TemplateSerializer.cs
@@ -22,7 +22,8 @@ namespace CardCreator.Services {
         var inner=(FrameworkElement)g.Children[0];
         var item=new TemplateItem{
           X=Canvas.GetLeft(g), Y=Canvas.GetTop(g), Width=g.Width, Height=g.Height, Rotation=GetRotation(inner), Z=z++,
-          Hidden=inner.Visibility!=Visibility.Visible
+          Hidden=inner.Visibility!=Visibility.Visible,
+          Label=inner.Tag is string t && !string.IsNullOrWhiteSpace(t) ? t : null
         };
         if(inner is TextBlock tb){
           item.Type="Text"; item.Text=tb.Text; item.FontSize=tb.FontSize; item.Bold=tb.FontWeight==FontWeights.Bold;
@@ -67,6 +68,7 @@ namespace CardCreator.Services {
         inner.RenderTransformOrigin=new Point(0.5,0.5);
         ApplyRotation(inner, item.Rotation);
         var container=new Grid{ Background=item.Type=="Image"? (item.Hidden==true?Brushes.Transparent:Brushes.White) : Brushes.Transparent, Width=item.Width, Height=item.Height };
+        if(!string.IsNullOrWhiteSpace(item.Label)) { inner.Tag=item.Label; container.Tag=item.Label; }
         container.Children.Add(inner);
         Canvas.SetLeft(container,item.X); Canvas.SetTop(container,item.Y);
         canvas.Children.Add(container);
@@ -81,6 +83,8 @@ namespace CardCreator.Services {
         if(obj is not Grid g || g.Children.Count==0) continue;
         var inner=(FrameworkElement)g.Children[0];
         double x=Canvas.GetLeft(g), y=Canvas.GetTop(g);
+        string tagAttr="";
+        if(inner.Tag is string tag && !string.IsNullOrWhiteSpace(tag)) tagAttr=" Tag=\""+XmlEscape(tag)+"\"";
         if(inner is TextBlock tb){
           string color="#000000";
           if(tb.Foreground is SolidColorBrush scb) color=$"#{scb.Color.R:X2}{scb.Color.G:X2}{scb.Color.B:X2}";
@@ -91,7 +95,7 @@ namespace CardCreator.Services {
             " FontStyle=\""+(tb.FontStyle==FontStyles.Italic?"Italic":"Normal")+"\""+
             " TextAlignment=\""+tb.TextAlignment+"\""+
             " Foreground=\""+color+"\""+
-            " Width=\""+g.Width+"\" Height=\""+g.Height+"\" Canvas.Left=\""+x+"\" Canvas.Top=\""+y+"\"";
+            " Width=\""+g.Width+"\" Height=\""+g.Height+"\" Canvas.Left=\""+x+"\" Canvas.Top=\""+y+"\""+tagAttr;
           if(tb.Visibility!=Visibility.Visible) attrs+=" Visibility=\""+tb.Visibility+"\"";
           sb.AppendLine("  <TextBlock"+attrs+">");
           var angle=GetRotation(inner);
@@ -100,7 +104,7 @@ namespace CardCreator.Services {
         } else if(inner is Image img){
           string srcAttr="";
           if(img.Source is BitmapImage bi && bi.UriSource!=null) srcAttr=" Source=\""+XmlEscape(bi.UriSource.ToString())+"\"";
-          var attrs=srcAttr+" Stretch=\""+img.Stretch+"\" Width=\""+g.Width+"\" Height=\""+g.Height+"\" Canvas.Left=\""+x+"\" Canvas.Top=\""+y+"\"";
+          var attrs=srcAttr+" Stretch=\""+img.Stretch+"\" Width=\""+g.Width+"\" Height=\""+g.Height+"\" Canvas.Left=\""+x+"\" Canvas.Top=\""+y+"\""+tagAttr;
           if(img.Visibility!=Visibility.Visible) attrs+=" Visibility=\""+img.Visibility+"\"";
           sb.AppendLine("  <Image"+attrs+">");
           var angle=GetRotation(inner);


### PR DESCRIPTION
## Summary
- Split inspector into common, text, and image sections that show only when applicable
- Move "Show Guidelines" option into View menu and remove Delete Selected button
- Allow deleting selected elements with the Delete key
- Keep inspector X/Y fields synced with element position for drag and manual edits
- Add Label field to inspector and persist element labels in JSON and XAML templates

## Testing
- `dotnet build CardCreator.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c268505bd08326a665bfa235e43f55