### PR TITLE
Add card image and sheet export

### DIFF
--- a/CardCreator/CardCreator.csproj
+++ b/CardCreator/CardCreator.csproj
@@ -3,7 +3,9 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>net8.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
+    <UseWindowsForms>true</UseWindowsForms>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
+    <ImplicitUsings>disable</ImplicitUsings>
   </PropertyGroup>
 </Project>

--- a/CardCreator/MainWindow.xaml
+++ b/CardCreator/MainWindow.xaml
@@ -33,6 +33,9 @@
                 <Separator/>
                 <MenuItem Header="Save _Data CSV..." Command="{Binding SaveCsvCommand}"/>
                 <MenuItem Header="Load _Data CSV..." Command="{Binding LoadCsvCommand}"/>
+                <Separator/>
+                <MenuItem Header="Save Card _Images..." Command="{Binding SaveImagesCommand}"/>
+                <MenuItem Header="Save Card _Sheets..." Command="{Binding SaveSheetsCommand}"/>
             </MenuItem>
             <MenuItem Header="_Insert">
                 <MenuItem Header="Add _Text" Command="{Binding AddTextCommand}">

--- a/CardCreator/SheetDialog.xaml
+++ b/CardCreator/SheetDialog.xaml
@@ -1,0 +1,19 @@
+<Window x:Class="CardCreator.SheetDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Sheet Settings" SizeToContent="WidthAndHeight" WindowStartupLocation="CenterOwner">
+    <StackPanel Margin="10">
+        <StackPanel Orientation="Horizontal">
+            <TextBlock Text="Columns" VerticalAlignment="Center"/>
+            <TextBox x:Name="ColumnsBox" Width="60" Margin="10,0,0,0"/>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+            <TextBlock Text="Rows" VerticalAlignment="Center"/>
+            <TextBox x:Name="RowsBox" Width="60" Margin="37,0,0,0"/>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+            <Button Content="OK" IsDefault="True" Width="75" Margin="0,0,8,0" Click="Ok_Click"/>
+            <Button Content="Cancel" IsCancel="True" Width="75"/>
+        </StackPanel>
+    </StackPanel>
+</Window>

--- a/CardCreator/SheetDialog.xaml.cs
+++ b/CardCreator/SheetDialog.xaml.cs
@@ -1,0 +1,21 @@
+using System.Windows;
+
+namespace CardCreator;
+
+public partial class SheetDialog : Window
+{
+    public int Columns { get; private set; }
+    public int Rows { get; private set; }
+    public SheetDialog(int cols, int rows)
+    {
+        InitializeComponent();
+        ColumnsBox.Text = cols.ToString();
+        RowsBox.Text = rows.ToString();
+    }
+    private void Ok_Click(object sender, RoutedEventArgs e)
+    {
+        if (!int.TryParse(ColumnsBox.Text, out var cols) || cols <= 0) { MessageBox.Show("Invalid columns"); return; }
+        if (!int.TryParse(RowsBox.Text, out var rows) || rows <= 0) { MessageBox.Show("Invalid rows"); return; }
+        Columns = cols; Rows = rows; DialogResult = true;
+    }
+}


### PR DESCRIPTION
## Summary
- allow saving each card as PNG/JPEG using RenderTargetBitmap
- add sheet export with grid size dialog and duplication by quantity
- enable Windows Forms and Windows targeting to support folder selection

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68c347e090a883269025bb17bc10b16a