### PR TITLE
Refactor layout and settings

### DIFF
--- a/CardCreator/MainWindow.xaml
+++ b/CardCreator/MainWindow.xaml
@@ -50,13 +50,15 @@
                 </MenuItem>
             </MenuItem>
             <MenuItem Header="_Edit">
-                <MenuItem Header="Align _Left" Command="{Binding AlignLeftCommand}"/>
-                <MenuItem Header="Align _Center" Command="{Binding AlignCenterCommand}"/>
-                <MenuItem Header="Align _Right" Command="{Binding AlignRightCommand}"/>
-                <Separator/>
-                <MenuItem Header="Align _Top" Command="{Binding AlignTopCommand}"/>
-                <MenuItem Header="Align _Middle" Command="{Binding AlignMiddleCommand}"/>
-                <MenuItem Header="Align _Bottom" Command="{Binding AlignBottomCommand}"/>
+                <MenuItem Header="_Align">
+                    <MenuItem Header="Align _Left" Command="{Binding AlignLeftCommand}"/>
+                    <MenuItem Header="Align _Center" Command="{Binding AlignCenterCommand}"/>
+                    <MenuItem Header="Align _Right" Command="{Binding AlignRightCommand}"/>
+                    <Separator/>
+                    <MenuItem Header="Align _Top" Command="{Binding AlignTopCommand}"/>
+                    <MenuItem Header="Align _Middle" Command="{Binding AlignMiddleCommand}"/>
+                    <MenuItem Header="Align _Bottom" Command="{Binding AlignBottomCommand}"/>
+                </MenuItem>
                 <Separator/>
                 <MenuItem Header="Distribute _Horizontally" Command="{Binding DistributeHCommand}"/>
                 <MenuItem Header="Distribute _Vertically" Command="{Binding DistributeVCommand}"/>
@@ -64,7 +66,7 @@
                 <MenuItem Header="_Bring Forward" Command="{Binding BringForwardCommand}"/>
                 <MenuItem Header="_Send Backward" Command="{Binding SendBackwardCommand}"/>
                 <Separator/>
-                <MenuItem Header="Sheet _Settings..." Command="{Binding SheetSettingsCommand}"/>
+                <MenuItem Header="Card && Sheet _Settings..." Command="{Binding SettingsCommand}"/>
             </MenuItem>
             <MenuItem Header="_View">
                 <MenuItem Header="_Snap" IsCheckable="True" IsChecked="{Binding SnapEnabled}"/>
@@ -75,35 +77,14 @@
                     <MenuItem Header="20" IsCheckable="True" IsChecked="{Binding GridSize, Converter={StaticResource GridSizeToBool}, ConverterParameter=20}"/>
                     <MenuItem Header="25" IsCheckable="True" IsChecked="{Binding GridSize, Converter={StaticResource GridSizeToBool}, ConverterParameter=25}"/>
                 </MenuItem>
-                <MenuItem Header="_Card Size..." Command="{Binding ChangeCardSizeCommand}"/>
             </MenuItem>
         </Menu>
         <Grid>
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="200"/>
                 <ColumnDefinition/>
                 <ColumnDefinition Width="360"/>
             </Grid.ColumnDefinitions>
-            <Border Grid.Column="0" Margin="0,0,12,0" Padding="12" Background="White" BorderBrush="#FFCCD1D8" BorderThickness="1" CornerRadius="12">
-                <StackPanel>
-                    <TextBlock Text="Cards" FontSize="18" FontWeight="Bold" Margin="0,0,0,8"/>
-                    <ListView ItemsSource="{Binding Cards}" SelectedItem="{Binding SelectedCard}">
-                        <ListView.ItemTemplate>
-                            <DataTemplate>
-                                <StackPanel Orientation="Horizontal">
-                                    <TextBox Width="100" Text="{Binding Name, UpdateSourceTrigger=PropertyChanged}"/>
-                                    <TextBox Width="40" Margin="6,0,0,0" Text="{Binding Quantity, UpdateSourceTrigger=PropertyChanged}"/>
-                                </StackPanel>
-                            </DataTemplate>
-                        </ListView.ItemTemplate>
-                    </ListView>
-                    <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
-                        <Button Content="Add" Command="{Binding AddCardCommand}" Width="60"/>
-                        <Button Content="Remove" Command="{Binding RemoveCardCommand}" Width="60" Margin="8,0,0,0"/>
-                    </StackPanel>
-                </StackPanel>
-            </Border>
-            <ScrollViewer Grid.Column="1" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" Background="#FFEFF1F4">
+            <ScrollViewer Grid.Column="0" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" Background="#FFEFF1F4">
                 <Grid Margin="20">
                     <Border Width="{Binding CardWidth}" Height="{Binding CardHeight}" CornerRadius="24" BorderBrush="#FFCCD1D8" BorderThickness="2" Background="{StaticResource CheckerBrush}">
                         <Canvas x:Name="CardCanvas" Width="{Binding CardWidth}" Height="{Binding CardHeight}" Background="Transparent" Focusable="True"
@@ -117,17 +98,18 @@
                     </Border>
                 </Grid>
             </ScrollViewer>
-            <Border Grid.Column="2" Margin="12,0,0,0" Padding="12" Background="White" BorderBrush="#FFCCD1D8" BorderThickness="1" CornerRadius="12">
-                <StackPanel>
-                    <TextBlock Text="Inspector" FontSize="18" FontWeight="Bold" Margin="0,0,0,8"/>
-                    <ItemsControl ItemsSource="{Binding SelectedItems}">
-                        <ItemsControl.ItemTemplate>
-                            <DataTemplate>
-                                <TextBlock Text="{Binding Tag}"/>
-                            </DataTemplate>
-                        </ItemsControl.ItemTemplate>
-                    </ItemsControl>
-                    <StackPanel DataContext="{Binding Inspector}" Margin="0,12,0,0">
+            <Border Grid.Column="1" Margin="12,0,0,0" Padding="12" Background="White" BorderBrush="#FFCCD1D8" BorderThickness="1" CornerRadius="12">
+                <TabControl>
+                    <TabItem Header="Inspector">
+                        <StackPanel>
+                            <ItemsControl ItemsSource="{Binding SelectedItems}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text="{Binding Tag}"/>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                            <StackPanel DataContext="{Binding Inspector}" Margin="0,12,0,0">
                         <Grid>
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto"/>
@@ -215,7 +197,27 @@
                             </StackPanel>
                         </Grid>
                     </StackPanel>
-                </StackPanel>
+                        </StackPanel>
+                    </TabItem>
+                    <TabItem Header="Cards">
+                        <StackPanel>
+                            <ListView ItemsSource="{Binding Cards}" SelectedItem="{Binding SelectedCard}">
+                                <ListView.ItemTemplate>
+                                    <DataTemplate>
+                                        <StackPanel Orientation="Horizontal">
+                                            <TextBox Width="100" Text="{Binding Name, UpdateSourceTrigger=PropertyChanged}"/>
+                                            <TextBox Width="40" Margin="6,0,0,0" Text="{Binding Quantity, UpdateSourceTrigger=PropertyChanged}"/>
+                                        </StackPanel>
+                                    </DataTemplate>
+                                </ListView.ItemTemplate>
+                            </ListView>
+                            <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                                <Button Content="Add" Command="{Binding AddCardCommand}" Width="60"/>
+                                <Button Content="Remove" Command="{Binding RemoveCardCommand}" Width="60" Margin="8,0,0,0"/>
+                            </StackPanel>
+                        </StackPanel>
+                    </TabItem>
+                </TabControl>
             </Border>
         </Grid>
     </DockPanel>

--- a/CardCreator/MainWindow.xaml.cs
+++ b/CardCreator/MainWindow.xaml.cs
@@ -29,7 +29,6 @@ public partial class MainWindow : Window
         Resources["NullToBoolInverse"] = new NullToBoolInverseConverter();
         InitializeComponent();
         VM.AttachCanvas(CardCanvas, GuideH, GuideV, Marquee);
-        VM.AddCard();
     }
     private void CardCanvas_MouseLeftButtonDown(object s, MouseButtonEventArgs e) => VM.OnCanvasMouseLeftDown(e);
     private void CardCanvas_MouseMove(object s, MouseEventArgs e) => VM.OnCanvasMouseMove(e);
@@ -71,14 +70,13 @@ public class MainViewModel : INotifyPropertyChanged
     public RelayCommand DistributeVCommand { get; }
     public RelayCommand BringForwardCommand { get; }
     public RelayCommand SendBackwardCommand { get; }
-    public RelayCommand ChangeCardSizeCommand { get; }
+    public RelayCommand SettingsCommand { get; }
     public RelayCommand AddCardCommand { get; }
     public RelayCommand RemoveCardCommand { get; }
     public RelayCommand SaveCsvCommand { get; }
     public RelayCommand LoadCsvCommand { get; }
     public RelayCommand SaveImagesCommand { get; }
     public RelayCommand SaveSheetsCommand { get; }
-    public RelayCommand SheetSettingsCommand { get; }
 
     public SelectedElementViewModel Inspector { get; } = new();
     private readonly List<Grid> _selected = new();
@@ -193,8 +191,8 @@ public class MainViewModel : INotifyPropertyChanged
         SendBackwardCommand = new RelayCommand(
             _ => ChangeZ(-1),
             _ => _selected.Count >= 1);
-        ChangeCardSizeCommand = new RelayCommand(
-            _ => ChangeCardSize());
+        SettingsCommand = new RelayCommand(
+            _ => ChangeSettings());
         AddCardCommand = new RelayCommand(
             _ => AddCard());
         RemoveCardCommand = new RelayCommand(
@@ -210,8 +208,6 @@ public class MainViewModel : INotifyPropertyChanged
         SaveSheetsCommand = new RelayCommand(
             _ => SaveSheets(),
             _ => Cards.Count > 0);
-        SheetSettingsCommand = new RelayCommand(
-            _ => ConfigureSheet());
         Cards.CollectionChanged += (_, __) =>
         {
             SaveImagesCommand.RaiseCanExecuteChanged();
@@ -220,11 +216,16 @@ public class MainViewModel : INotifyPropertyChanged
         Inspector.PropertyChanged += OnInspectorPropertyChanged;
     }
 
-    private void ConfigureSheet()
+    private void ChangeSettings()
     {
-        var dlg = new SheetDialog(_sheetColumns, _sheetRows, _useJpeg) { Owner = Application.Current.MainWindow };
+        var dlg = new SettingsDialog(CardWidth, CardHeight, _sheetColumns, _sheetRows, _useJpeg)
+        {
+            Owner = Application.Current.MainWindow
+        };
         if (dlg.ShowDialog() == true)
         {
+            CardWidth = dlg.VM.WidthDip;
+            CardHeight = dlg.VM.HeightDip;
             _sheetColumns = dlg.Columns;
             _sheetRows = dlg.Rows;
             _useJpeg = dlg.UseJpeg;
@@ -1267,15 +1268,6 @@ public class MainViewModel : INotifyPropertyChanged
             _guideH.Visibility = Visibility.Collapsed;
     }
 
-    private void ChangeCardSize()
-    {
-        var dlg = new CanvasSizeDialog(CardWidth, CardHeight) { Owner = Application.Current.MainWindow };
-        if (dlg.ShowDialog() == true)
-        {
-            CardWidth = dlg.VM.WidthDip;
-            CardHeight = dlg.VM.HeightDip;
-        }
-    }
     private void HideGuides()
     {
         if (_guideH != null)

--- a/CardCreator/SettingsDialog.xaml
+++ b/CardCreator/SettingsDialog.xaml
@@ -1,0 +1,47 @@
+<Window x:Class="CardCreator.SettingsDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Card and Sheet Settings" SizeToContent="WidthAndHeight" WindowStartupLocation="CenterOwner">
+    <StackPanel Margin="10">
+        <ComboBox ItemsSource="{Binding VM.Presets}" DisplayMemberPath="Name" SelectedItem="{Binding VM.SelectedPreset}" Margin="0,0,0,10"/>
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="100"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="100"/>
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition/>
+                <RowDefinition/>
+            </Grid.RowDefinitions>
+            <TextBlock Text="Width (in)" VerticalAlignment="Center"/>
+            <TextBox Grid.Column="1" Text="{Binding VM.WidthInch, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, StringFormat=F2}" Margin="4,0"/>
+            <TextBlock Grid.Column="2" Text="Width (DIP)" Margin="10,0,0,0" VerticalAlignment="Center"/>
+            <TextBox Grid.Column="3" Text="{Binding VM.WidthDip, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, StringFormat=F0}" Margin="4,0"/>
+            <TextBlock Grid.Row="1" Text="Height (in)" VerticalAlignment="Center"/>
+            <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding VM.HeightInch, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, StringFormat=F2}" Margin="4,0"/>
+            <TextBlock Grid.Row="1" Grid.Column="2" Text="Height (DIP)" Margin="10,0,0,0" VerticalAlignment="Center"/>
+            <TextBox Grid.Row="1" Grid.Column="3" Text="{Binding VM.HeightDip, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, StringFormat=F0}" Margin="4,0"/>
+        </Grid>
+        <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
+            <TextBlock Text="Columns" VerticalAlignment="Center"/>
+            <TextBox x:Name="ColumnsBox" Width="60" Margin="10,0,0,0"/>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+            <TextBlock Text="Rows" VerticalAlignment="Center"/>
+            <TextBox x:Name="RowsBox" Width="60" Margin="37,0,0,0"/>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+            <TextBlock Text="Format" VerticalAlignment="Center"/>
+            <ComboBox x:Name="FormatBox" Width="80" Margin="28,0,0,0">
+                <ComboBoxItem Content="PNG"/>
+                <ComboBoxItem Content="JPEG"/>
+            </ComboBox>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+            <Button Content="OK" IsDefault="True" Width="75" Margin="0,0,8,0" Click="Ok_Click"/>
+            <Button Content="Cancel" IsCancel="True" Width="75"/>
+        </StackPanel>
+    </StackPanel>
+</Window>

--- a/CardCreator/SettingsDialog.xaml.cs
+++ b/CardCreator/SettingsDialog.xaml.cs
@@ -1,0 +1,39 @@
+using System.Windows;
+
+namespace CardCreator;
+
+public partial class SettingsDialog : Window
+{
+    public CanvasSizeViewModel VM { get; }
+    public int Columns { get; private set; }
+    public int Rows { get; private set; }
+    public bool UseJpeg { get; private set; }
+
+    public SettingsDialog(double widthDip, double heightDip, int cols, int rows, bool useJpeg)
+    {
+        InitializeComponent();
+        VM = new CanvasSizeViewModel(widthDip, heightDip);
+        ColumnsBox.Text = cols.ToString();
+        RowsBox.Text = rows.ToString();
+        FormatBox.SelectedIndex = useJpeg ? 1 : 0;
+        DataContext = this;
+    }
+
+    private void Ok_Click(object sender, RoutedEventArgs e)
+    {
+        if (!int.TryParse(ColumnsBox.Text, out var cols) || cols <= 0)
+        {
+            MessageBox.Show("Invalid columns");
+            return;
+        }
+        if (!int.TryParse(RowsBox.Text, out var rows) || rows <= 0)
+        {
+            MessageBox.Show("Invalid rows");
+            return;
+        }
+        Columns = cols;
+        Rows = rows;
+        UseJpeg = FormatBox.SelectedIndex == 1;
+        DialogResult = true;
+    }
+}


### PR DESCRIPTION
## Summary
- Consolidate Inspector and card list into a TabControl on the right side of the main window
- Group alignment actions under a new Align submenu and relocate card/sheet settings under Edit
- Merge card size and sheet settings into a single settings dialog

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c36e0e07b08326ad501cc02fbb7ac4