### PR TITLE
Add rulers and unit selection

### DIFF
--- a/CardCreator/EnumToBoolConverter.cs
+++ b/CardCreator/EnumToBoolConverter.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace CardCreator
+{
+    public class EnumToBoolConverter : IValueConverter
+    {
+        public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            if (value == null || parameter == null) return false;
+            return value.ToString() == parameter.ToString();
+        }
+
+        public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            if (value is bool b && b && parameter != null)
+            {
+                return Enum.Parse(targetType, parameter.ToString()!);
+            }
+            return Binding.DoNothing;
+        }
+    }
+}

--- a/CardCreator/MainWindow.xaml
+++ b/CardCreator/MainWindow.xaml
@@ -8,6 +8,7 @@
     <Window.Resources>
         <BooleanToVisibilityConverter x:Key="BoolToVis"/>
         <local:GridSizeToBoolConverter x:Key="GridSizeToBool"/>
+        <local:EnumToBoolConverter x:Key="EnumToBool"/>
     </Window.Resources>
     <Window.DataContext>
         <local:MainViewModel/>
@@ -77,6 +78,11 @@
                     <MenuItem Header="20" IsCheckable="True" IsChecked="{Binding GridSize, Converter={StaticResource GridSizeToBool}, ConverterParameter=20}"/>
                     <MenuItem Header="25" IsCheckable="True" IsChecked="{Binding GridSize, Converter={StaticResource GridSizeToBool}, ConverterParameter=25}"/>
                 </MenuItem>
+                <MenuItem Header="_Units">
+                    <MenuItem Header="_Inches" IsCheckable="True" IsChecked="{Binding Units, Converter={StaticResource EnumToBool}, ConverterParameter=Inches}"/>
+                    <MenuItem Header="_Millimeters" IsCheckable="True" IsChecked="{Binding Units, Converter={StaticResource EnumToBool}, ConverterParameter=Millimeters}"/>
+                    <MenuItem Header="_Device Independent" IsCheckable="True" IsChecked="{Binding Units, Converter={StaticResource EnumToBool}, ConverterParameter=DeviceIndependent}"/>
+                </MenuItem>
             </MenuItem>
         </Menu>
         <Grid>
@@ -85,12 +91,23 @@
                 <ColumnDefinition Width="360"/>
             </Grid.ColumnDefinitions>
             <ScrollViewer Grid.Column="0" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" Background="#FFEFF1F4">
-                <Grid Margin="20">
-                    <Border Width="{Binding CardWidth}" Height="{Binding CardHeight}" CornerRadius="24" BorderBrush="#FFCCD1D8" BorderThickness="2" Background="{StaticResource CheckerBrush}">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="20"/>
+                        <RowDefinition/>
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="20"/>
+                        <ColumnDefinition/>
+                    </Grid.ColumnDefinitions>
+                    <local:Ruler x:Name="RulerH" Grid.Row="0" Grid.Column="1" Height="20" Orientation="Horizontal" Units="{Binding Units}"/>
+                    <local:Ruler x:Name="RulerV" Grid.Row="1" Grid.Column="0" Width="20" Orientation="Vertical" Units="{Binding Units}"/>
+                    <Border Grid.Row="1" Grid.Column="1" Width="{Binding CardWidth}" Height="{Binding CardHeight}" CornerRadius="24" BorderBrush="#FFCCD1D8" BorderThickness="2" Background="{StaticResource CheckerBrush}">
                         <Canvas x:Name="CardCanvas" Width="{Binding CardWidth}" Height="{Binding CardHeight}" Background="Transparent" Focusable="True"
               MouseLeftButtonDown="CardCanvas_MouseLeftButtonDown"
               MouseMove="CardCanvas_MouseMove"
-              MouseLeftButtonUp="CardCanvas_MouseLeftButtonUp">
+              MouseLeftButtonUp="CardCanvas_MouseLeftButtonUp"
+              MouseLeave="CardCanvas_MouseLeave">
                             <Line x:Name="GuideH" Stroke="#660078D7" StrokeThickness="1.5" Visibility="Collapsed"/>
                             <Line x:Name="GuideV" Stroke="#660078D7" StrokeThickness="1.5" Visibility="Collapsed"/>
                             <Rectangle x:Name="Marquee" Stroke="#770078D7" StrokeDashArray="3,2" Fill="#220078D7" Visibility="Collapsed"/>

--- a/CardCreator/MainWindow.xaml.cs
+++ b/CardCreator/MainWindow.xaml.cs
@@ -31,8 +31,19 @@ public partial class MainWindow : Window
         VM.AttachCanvas(CardCanvas, GuideH, GuideV, Marquee);
     }
     private void CardCanvas_MouseLeftButtonDown(object s, MouseButtonEventArgs e) => VM.OnCanvasMouseLeftDown(e);
-    private void CardCanvas_MouseMove(object s, MouseEventArgs e) => VM.OnCanvasMouseMove(e);
+    private void CardCanvas_MouseMove(object s, MouseEventArgs e)
+    {
+        VM.OnCanvasMouseMove(e);
+        var p = e.GetPosition(CardCanvas);
+        RulerH.Marker = p.X;
+        RulerV.Marker = p.Y;
+    }
     private void CardCanvas_MouseLeftButtonUp(object s, MouseButtonEventArgs e) => VM.OnCanvasMouseLeftUp(e);
+    private void CardCanvas_MouseLeave(object s, MouseEventArgs e)
+    {
+        RulerH.Marker = double.NaN;
+        RulerV.Marker = double.NaN;
+    }
     private void BrowseImage_Click(object s, RoutedEventArgs e)
     {
         if (!VM.HasSelection || VM.SingleSelectedInner is not Image)
@@ -142,6 +153,17 @@ public class MainViewModel : INotifyPropertyChanged
         get => _guidelinesEnabled;
         set {
             _guidelinesEnabled = value;
+            OnPropertyChanged();
+        }
+    }
+
+    private MeasurementUnit _units = MeasurementUnit.Inches;
+    public MeasurementUnit Units
+    {
+        get => _units;
+        set
+        {
+            _units = value;
             OnPropertyChanged();
         }
     }

--- a/CardCreator/MeasurementUnit.cs
+++ b/CardCreator/MeasurementUnit.cs
@@ -1,0 +1,9 @@
+namespace CardCreator
+{
+    public enum MeasurementUnit
+    {
+        Inches,
+        Millimeters,
+        DeviceIndependent
+    }
+}

--- a/CardCreator/Ruler.cs
+++ b/CardCreator/Ruler.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Media;
+
+namespace CardCreator
+{
+    public class Ruler : FrameworkElement
+    {
+        public static readonly DependencyProperty OrientationProperty = DependencyProperty.Register(
+            nameof(Orientation), typeof(Orientation), typeof(Ruler),
+            new FrameworkPropertyMetadata(Orientation.Horizontal, FrameworkPropertyMetadataOptions.AffectsRender));
+
+        public static readonly DependencyProperty UnitsProperty = DependencyProperty.Register(
+            nameof(Units), typeof(MeasurementUnit), typeof(Ruler),
+            new FrameworkPropertyMetadata(MeasurementUnit.Inches, FrameworkPropertyMetadataOptions.AffectsRender));
+
+        public static readonly DependencyProperty MarkerProperty = DependencyProperty.Register(
+            nameof(Marker), typeof(double), typeof(Ruler),
+            new FrameworkPropertyMetadata(double.NaN, FrameworkPropertyMetadataOptions.AffectsRender));
+
+        public Orientation Orientation
+        {
+            get => (Orientation)GetValue(OrientationProperty);
+            set => SetValue(OrientationProperty, value);
+        }
+
+        public MeasurementUnit Units
+        {
+            get => (MeasurementUnit)GetValue(UnitsProperty);
+            set => SetValue(UnitsProperty, value);
+        }
+
+        public double Marker
+        {
+            get => (double)GetValue(MarkerProperty);
+            set => SetValue(MarkerProperty, value);
+        }
+
+        private double UnitsToDiu()
+        {
+            return Units switch
+            {
+                MeasurementUnit.Inches => 96.0,
+                MeasurementUnit.Millimeters => 96.0 / 25.4,
+                _ => 1.0,
+            };
+        }
+
+        protected override void OnRender(DrawingContext dc)
+        {
+            base.OnRender(dc);
+
+            double scale = UnitsToDiu();
+            double length = Orientation == Orientation.Horizontal ? ActualWidth : ActualHeight;
+            var pen = new Pen(Brushes.Gray, 1);
+            var textBrush = Brushes.Black;
+            var typeface = new Typeface("Segoe UI");
+            double tickLengthMajor = 10;
+            double tickLengthMinor = 5;
+
+            for (double u = 0; u <= length / scale; u++)
+            {
+                double pos = Math.Round(u * scale) + 0.5; // crisp lines
+                Point p1, p2;
+                if (Orientation == Orientation.Horizontal)
+                {
+                    p1 = new Point(pos, ActualHeight);
+                    p2 = new Point(pos, ActualHeight - tickLengthMajor);
+                }
+                else
+                {
+                    p1 = new Point(ActualWidth, pos);
+                    p2 = new Point(ActualWidth - tickLengthMajor, pos);
+                }
+                dc.DrawLine(pen, p1, p2);
+
+                var ft = new FormattedText(u.ToString(CultureInfo.InvariantCulture), CultureInfo.InvariantCulture,
+                    FlowDirection.LeftToRight, typeface, 8, textBrush, VisualTreeHelper.GetDpi(this).PixelsPerDip);
+                if (Orientation == Orientation.Horizontal)
+                    dc.DrawText(ft, new Point(pos + 2, 0));
+                else
+                    dc.DrawText(ft, new Point(0, pos + 2));
+
+                // minor ticks
+                if (scale >= 10)
+                {
+                    for (int m = 1; m < 10; m++)
+                    {
+                        double mpos = pos + m * scale / 10;
+                        if (mpos > length) break;
+                        Point mp1, mp2;
+                        if (Orientation == Orientation.Horizontal)
+                        {
+                            mp1 = new Point(mpos, ActualHeight);
+                            mp2 = new Point(mpos, ActualHeight - tickLengthMinor);
+                        }
+                        else
+                        {
+                            mp1 = new Point(ActualWidth, mpos);
+                            mp2 = new Point(ActualWidth - tickLengthMinor, mpos);
+                        }
+                        dc.DrawLine(pen, mp1, mp2);
+                    }
+                }
+            }
+
+            if (!double.IsNaN(Marker))
+            {
+                var markerPen = new Pen(Brushes.Red, 1);
+                if (Orientation == Orientation.Horizontal)
+                {
+                    double x = Marker + 0.5;
+                    dc.DrawLine(markerPen, new Point(x, 0), new Point(x, ActualHeight));
+                }
+                else
+                {
+                    double y = Marker + 0.5;
+                    dc.DrawLine(markerPen, new Point(0, y), new Point(ActualWidth, y));
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add horizontal/vertical rulers around card canvas with crosshair tracking
- allow users to switch ruler units between inches, millimeters, and device independent units
- highlight mouse position on rulers and expose units setting via View menu

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3723d52f0832687c8cc18be4db4e6