### PR TITLE
Use RichTextBox for template text items

### DIFF
--- a/CardCreator/MainWindow.xaml
+++ b/CardCreator/MainWindow.xaml
@@ -181,7 +181,7 @@
                                         <ColumnDefinition/>
                                     </Grid.ColumnDefinitions>
                                     <TextBlock Text="Text" Grid.Row="0" Grid.Column="0" VerticalAlignment="Center"/>
-                                    <TextBox Text="{Binding Text, UpdateSourceTrigger=PropertyChanged}" Grid.Row="0" Grid.Column="1" AcceptsReturn="True"/>
+                                    <RichTextBox Document="{Binding Document}" Grid.Row="0" Grid.Column="1" AcceptsReturn="True"/>
                                     <TextBlock Text="Font Size" Grid.Row="1" Grid.Column="0" VerticalAlignment="Center"/>
                                     <TextBox Text="{Binding FontSize, UpdateSourceTrigger=PropertyChanged, StringFormat=F0}" Grid.Row="1" Grid.Column="1"/>
                                     <TextBlock Text="Font Family" Grid.Row="2" Grid.Column="0" VerticalAlignment="Center"/>


### PR DESCRIPTION
## Summary
- replace TextBlock template items with non-interactive RichTextBox controls
- expose RichTextBox FlowDocument editing in inspector
- persist FlowDocument content through JSON/XAML/CSV serialization

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c42f4358c88326b8160cefffd7cc74