### PR TITLE
Sync inspector RichTextBox with view model

### DIFF
--- a/CardCreator/MainWindow.xaml
+++ b/CardCreator/MainWindow.xaml
@@ -181,7 +181,7 @@
                                         <ColumnDefinition/>
                                     </Grid.ColumnDefinitions>
                                     <TextBlock Text="Text" Grid.Row="0" Grid.Column="0" VerticalAlignment="Center"/>
-                                    <RichTextBox Document="{Binding Document}" Grid.Row="0" Grid.Column="1" AcceptsReturn="True"/>
+                                    <RichTextBox x:Name="InspectorRtb" Grid.Row="0" Grid.Column="1" AcceptsReturn="True" TextChanged="InspectorRtb_TextChanged"/>
                                     <TextBlock Text="Font Size" Grid.Row="1" Grid.Column="0" VerticalAlignment="Center"/>
                                     <TextBox Text="{Binding FontSize, UpdateSourceTrigger=PropertyChanged, StringFormat=F0}" Grid.Row="1" Grid.Column="1"/>
                                     <TextBlock Text="Font Family" Grid.Row="2" Grid.Column="0" VerticalAlignment="Center"/>

--- a/CardCreator/MainWindow.xaml.cs
+++ b/CardCreator/MainWindow.xaml.cs
@@ -28,6 +28,7 @@ namespace CardCreator
 public partial class MainWindow : Window
 {
     public MainViewModel VM => (MainViewModel)DataContext;
+    private bool _updatingInspector;
     public MainWindow()
     {
         Resources["NullToBoolInverse"] = new NullToBoolInverseConverter();
@@ -35,6 +36,8 @@ public partial class MainWindow : Window
         VM.AttachCanvas(CardCanvas, GuideH, GuideV, Marquee);
         Loaded += (_, __) => UpdateRulerOrigins();
         CardCanvas.SizeChanged += (_, __) => UpdateRulerOrigins();
+        VM.Inspector.PropertyChanged += Inspector_PropertyChanged;
+        InspectorRtb.Document = VM.Inspector.Document;
     }
     private void CardCanvas_MouseLeftButtonDown(object s, MouseButtonEventArgs e) => VM.OnCanvasMouseLeftDown(e);
     private void CardCanvas_MouseMove(object s, MouseEventArgs e)
@@ -51,6 +54,22 @@ public partial class MainWindow : Window
         RulerH.Marker = double.NaN;
         RulerV.Marker = double.NaN;
         MarkerReadout.Text = string.Empty;
+    }
+
+    private void Inspector_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (string.IsNullOrEmpty(e.PropertyName) || e.PropertyName == nameof(SelectedElementViewModel.Document))
+        {
+            _updatingInspector = true;
+            InspectorRtb.Document = VM.Inspector.Document;
+            _updatingInspector = false;
+        }
+    }
+
+    private void InspectorRtb_TextChanged(object s, TextChangedEventArgs e)
+    {
+        if (_updatingInspector) return;
+        VM.Inspector.Document = InspectorRtb.Document;
     }
 
     private void UpdateRulerOrigins()


### PR DESCRIPTION
## Summary
- Name inspector RichTextBox and attach TextChanged handler
- Sync inspector document with view model via PropertyChanged

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c4334c59688326ad3b02d8d511a88c