### PR TITLE
Add toolbar for editing rich text

### DIFF
--- a/CardCreator/MainWindow.xaml
+++ b/CardCreator/MainWindow.xaml
@@ -1,9 +1,7 @@
-<Window x:Class="CardCreator.MainWindow"
+ <Window x:Class="CardCreator.MainWindow"
  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
- xmlns:sys="clr-namespace:System;assembly=mscorlib"
  xmlns:local="clr-namespace:CardCreator"
- xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
  Title="Card Creator" Height="820" Width="1320"
  Background="#FFF9F9FB" KeyDown="Window_KeyDown">
     <Window.Resources>
@@ -86,6 +84,31 @@
                 <MenuItem Header="Show _Guidelines" IsCheckable="True" Visibility="Collapsed" IsChecked="{Binding GuidelinesEnabled}"/>
             </MenuItem>
         </Menu>
+        <ToolBar DockPanel.Dock="Top" DataContext="{Binding Inspector}" IsEnabled="{Binding IsText}">
+            <ComboBox Width="170" ItemsSource="{Binding FontFamilies}" SelectedItem="{Binding FontFamily}"/>
+            <ComboBox Width="60" Text="{Binding FontSize, UpdateSourceTrigger=PropertyChanged}"/>
+            <Separator/>
+            <Button Command="EditingCommands.ToggleBold" CommandTarget="{Binding Element}" FontWeight="Bold" Content="B"/>
+            <Button Command="EditingCommands.ToggleItalic" CommandTarget="{Binding Element}" FontStyle="Italic" Content="I"/>
+            <Button Command="EditingCommands.ToggleUnderline" CommandTarget="{Binding Element}">
+                <TextBlock Text="U" TextDecorations="Underline"/>
+            </Button>
+            <Button Command="EditingCommands.ToggleStrikethrough" CommandTarget="{Binding Element}">
+                <TextBlock Text="abc" TextDecorations="Strikethrough"/>
+            </Button>
+            <Separator/>
+            <Button Click="PickColor_Click" ToolTip="Text Color">
+                <Border Width="16" Height="16" Background="{Binding ForegroundBrush}" BorderBrush="Black" BorderThickness="1"/>
+            </Button>
+            <Separator/>
+            <Button Command="EditingCommands.AlignLeft" CommandTarget="{Binding Element}" Content="L"/>
+            <Button Command="EditingCommands.AlignCenter" CommandTarget="{Binding Element}" Content="C"/>
+            <Button Command="EditingCommands.AlignRight" CommandTarget="{Binding Element}" Content="R"/>
+            <Button Command="EditingCommands.AlignJustify" CommandTarget="{Binding Element}" Content="J"/>
+            <Separator/>
+            <Button Command="EditingCommands.ToggleBullets" CommandTarget="{Binding Element}" Content="•"/>
+            <Button Command="EditingCommands.ToggleNumbering" CommandTarget="{Binding Element}" Content="1."/>
+        </ToolBar>
         <Grid>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition/>
@@ -167,53 +190,7 @@
                                     <TextBlock Text="Hidden" Grid.Row="6" Grid.Column="0" VerticalAlignment="Center"/>
                                     <CheckBox IsChecked="{Binding IsHidden, UpdateSourceTrigger=PropertyChanged}" Grid.Row="6" Grid.Column="1" IsEnabled="{Binding Element, Converter={StaticResource NullToBoolInverse}}"/>
                                 </Grid>
-                                <Grid Visibility="{Binding IsText, Converter={StaticResource BoolToVis}}" Margin="0,10,0,0">
-                                    <Grid.RowDefinitions>
-                                        <RowDefinition Height="Auto"/>
-                                        <RowDefinition Height="Auto"/>
-                                        <RowDefinition Height="Auto"/>
-                                        <RowDefinition Height="Auto"/>
-                                        <RowDefinition Height="Auto"/>
-                                        <RowDefinition Height="Auto"/>
-                                    </Grid.RowDefinitions>
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="110"/>
-                                        <ColumnDefinition/>
-                                    </Grid.ColumnDefinitions>
-                                    <TextBlock Text="Text" Grid.Row="0" Grid.Column="0" VerticalAlignment="Center"/>
-                                    <RichTextBox x:Name="InspectorRtb" Grid.Row="0" Grid.Column="1" AcceptsReturn="True" TextChanged="InspectorRtb_TextChanged"/>
-                                    <TextBlock Text="Font Size" Grid.Row="1" Grid.Column="0" VerticalAlignment="Center"/>
-                                    <TextBox Text="{Binding FontSize, UpdateSourceTrigger=PropertyChanged, StringFormat=F0}" Grid.Row="1" Grid.Column="1"/>
-                                    <TextBlock Text="Font Family" Grid.Row="2" Grid.Column="0" VerticalAlignment="Center"/>
-                                    <ComboBox ItemsSource="{Binding FontFamilies}" SelectedItem="{Binding FontFamily, UpdateSourceTrigger=PropertyChanged}" Grid.Row="2" Grid.Column="1">
-                                        <ComboBox.ItemTemplate>
-                                            <DataTemplate>
-                                                <TextBlock Text="{Binding Source}" FontFamily="{Binding}"/>
-                                            </DataTemplate>
-                                        </ComboBox.ItemTemplate>
-                                    </ComboBox>
-                                    <TextBlock Text="Font Style" Grid.Row="3" Grid.Column="0" VerticalAlignment="Center"/>
-                                    <ComboBox SelectedItem="{Binding FontStyleOption, UpdateSourceTrigger=PropertyChanged}" Grid.Row="3" Grid.Column="1">
-                                        <sys:String>None</sys:String>
-                                        <sys:String>Italic</sys:String>
-                                        <sys:String>Bold</sys:String>
-                                        <sys:String>Bold Italic</sys:String>
-                                    </ComboBox>
-                                    <TextBlock Text="Text Align" Grid.Row="4" Grid.Column="0" VerticalAlignment="Center"/>
-                                    <ComboBox SelectedItem="{Binding TextAlignment, UpdateSourceTrigger=PropertyChanged}" Grid.Row="4" Grid.Column="1">
-                                        <TextAlignment>Left</TextAlignment>
-                                        <TextAlignment>Center</TextAlignment>
-                                        <TextAlignment>Right</TextAlignment>
-                                        <TextAlignment>Justify</TextAlignment>
-                                    </ComboBox>
-                                    <TextBlock Text="Color" Grid.Row="5" Grid.Column="0" VerticalAlignment="Center"/>
-                                    <Button Grid.Row="5" Grid.Column="1" Width="120" Click="PickColor_Click">
-                                        <StackPanel Orientation="Horizontal">
-                                            <Border Width="16" Height="16" Background="{Binding ForegroundBrush}" BorderBrush="Black" BorderThickness="1"/>
-                                            <TextBlock Text="{Binding ForegroundHex}" Margin="6,0,0,0" VerticalAlignment="Center"/>
-                                        </StackPanel>
-                                    </Button>
-                                </Grid>
+                                
                                 <Grid Visibility="{Binding IsImage, Converter={StaticResource BoolToVis}}" Margin="0,10,0,0">
                                     <Grid.RowDefinitions>
                                         <RowDefinition Height="Auto"/>

--- a/CardCreator/MainWindow.xaml.cs
+++ b/CardCreator/MainWindow.xaml.cs
@@ -28,7 +28,6 @@ namespace CardCreator
 public partial class MainWindow : Window
 {
     public MainViewModel VM => (MainViewModel)DataContext;
-    private bool _updatingInspector;
     public MainWindow()
     {
         Resources["NullToBoolInverse"] = new NullToBoolInverseConverter();
@@ -36,10 +35,6 @@ public partial class MainWindow : Window
         VM.AttachCanvas(CardCanvas, GuideH, GuideV, Marquee);
         Loaded += (_, __) => UpdateRulerOrigins();
         CardCanvas.SizeChanged += (_, __) => UpdateRulerOrigins();
-        VM.Inspector.PropertyChanged += Inspector_PropertyChanged;
-        _updatingInspector = true;
-        InspectorRtb.Document = CloneDocument(VM.Inspector.Document);
-        _updatingInspector = false;
     }
     private void CardCanvas_MouseLeftButtonDown(object s, MouseButtonEventArgs e) => VM.OnCanvasMouseLeftDown(e);
     private void CardCanvas_MouseMove(object s, MouseEventArgs e)
@@ -58,36 +53,7 @@ public partial class MainWindow : Window
         MarkerReadout.Text = string.Empty;
     }
 
-    private void Inspector_PropertyChanged(object? sender, PropertyChangedEventArgs e)
-    {
-        if (_updatingInspector) return;
-        if (string.IsNullOrEmpty(e.PropertyName) || e.PropertyName == nameof(SelectedElementViewModel.Document))
-        {
-            _updatingInspector = true;
-            InspectorRtb.Document = CloneDocument(VM.Inspector.Document);
-            _updatingInspector = false;
-        }
-    }
-
-    private void InspectorRtb_TextChanged(object s, TextChangedEventArgs e)
-    {
-        if (_updatingInspector) return;
-        _updatingInspector = true;
-        VM.Inspector.Document = CloneDocument(InspectorRtb.Document);
-        _updatingInspector = false;
-    }
-
-    private static FlowDocument CloneDocument(FlowDocument document)
-    {
-        var clone = new FlowDocument();
-        using var stream = new MemoryStream();
-        var range = new TextRange(document.ContentStart, document.ContentEnd);
-        range.Save(stream, DataFormats.XamlPackage);
-        stream.Position = 0;
-        var cloneRange = new TextRange(clone.ContentStart, clone.ContentEnd);
-        cloneRange.Load(stream, DataFormats.XamlPackage);
-        return clone;
-    }
+    
 
     private void UpdateRulerOrigins()
     {
@@ -496,7 +462,7 @@ public class MainViewModel : INotifyPropertyChanged
         if (_canvas == null)
             return;
         var tb = new RichTextBox { FontSize = 28, Foreground = Brushes.Black,
-                                 RenderTransformOrigin = new Point(0.5, 0.5), IsHitTestVisible = false };
+                                 RenderTransformOrigin = new Point(0.5, 0.5) };
         tb.Document = new FlowDocument(new Paragraph(new Run("Text")));
         var container = CreateContainer(tb, 60, 60, 180, 60);
         tb.Width = 180;

--- a/CardCreator/Services/TemplateSerializer.cs
+++ b/CardCreator/Services/TemplateSerializer.cs
@@ -65,7 +65,7 @@ namespace CardCreator.Services {
           if(item.Hidden==true) img.Visibility=Visibility.Hidden;
           inner=img;
         } else {
-          var rtb=new RichTextBox{ FontSize=item.FontSize??28, IsHitTestVisible=false };
+          var rtb=new RichTextBox{ FontSize=item.FontSize??28 };
           if(!string.IsNullOrWhiteSpace(item.Text)){
             try{ rtb.Document=(FlowDocument)XamlReader.Parse(item.Text); }
             catch{ rtb.Document=new FlowDocument(new Paragraph(new Run(item.Text))); }
@@ -97,7 +97,7 @@ namespace CardCreator.Services {
       if(obj!=null){
         canvas.Children.Clear();
         foreach(UIElement child in obj.Children){
-          if(child is RichTextBox rtb) rtb.IsHitTestVisible=false;
+          if(child is RichTextBox rtb) rtb.IsHitTestVisible=true;
           canvas.Children.Add(child);
         }
         model.CardWidth=obj.Width;
@@ -130,7 +130,7 @@ namespace CardCreator.Services {
             " FontWeight=\""+(rtb.FontWeight==FontWeights.Bold?"Bold":"Normal")+"\""+
             " FontStyle=\""+(rtb.FontStyle==FontStyles.Italic?"Italic":"Normal")+"\""+
             " Foreground=\""+color+"\""+
-            " Width=\""+g.Width+"\" Height=\""+g.Height+"\" Canvas.Left=\""+x+"\" Canvas.Top=\""+y+"\" IsHitTestVisible=\"False\""+tagAttr;
+            " Width=\""+g.Width+"\" Height=\""+g.Height+"\" Canvas.Left=\""+x+"\" Canvas.Top=\""+y+"\""+tagAttr;
           if(rtb.Visibility!=Visibility.Visible) attrs+=" Visibility=\""+rtb.Visibility+"\"";
           sb.AppendLine("  <RichTextBox"+attrs+">");
           var angle=GetRotation(inner);


### PR DESCRIPTION
## Summary
- add toolbar for rich text formatting below menu
- remove inspector controls tied to obsolete text block editing
- keep RichTextBox hit testable and include in templates

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c442c34f908326a27befa99622e200