### PR TITLE
Add toolbar for editing rich text

### DIFF
--- a/CardCreator/MainWindow.xaml
+++ b/CardCreator/MainWindow.xaml
@@ -1,9 +1,7 @@
-<Window x:Class="CardCreator.MainWindow"
+ <Window x:Class="CardCreator.MainWindow"
  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
- xmlns:sys="clr-namespace:System;assembly=mscorlib"
  xmlns:local="clr-namespace:CardCreator"
- xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
  Title="Card Creator" Height="820" Width="1320"
  Background="#FFF9F9FB" KeyDown="Window_KeyDown">
     <Window.Resources>
@@ -86,6 +84,41 @@
                 <MenuItem Header="Show _Guidelines" IsCheckable="True" Visibility="Collapsed" IsChecked="{Binding GuidelinesEnabled}"/>
             </MenuItem>
         </Menu>
+        <ToolBar DockPanel.Dock="Top" DataContext="{Binding Inspector}" IsEnabled="{Binding IsText}">
+            <ComboBox Width="170" ItemsSource="{Binding FontFamilies}" SelectedItem="{Binding FontFamily}">
+                <ComboBox.ItemTemplate>
+                    <DataTemplate>
+                        <TextBlock Text="{Binding Source}" FontFamily="{Binding}"/>
+                    </DataTemplate>
+                </ComboBox.ItemTemplate>
+            </ComboBox>
+            <ComboBox Width="60" IsEditable="True" ItemsSource="{Binding FontSizes}" Text="{Binding FontSize, UpdateSourceTrigger=PropertyChanged}"/>
+            <Separator/>
+            <Button Command="EditingCommands.ToggleBold" CommandTarget="{Binding Element}" FontWeight="Bold" Content="B"/>
+            <Button Command="EditingCommands.ToggleItalic" CommandTarget="{Binding Element}" FontStyle="Italic" Content="I"/>
+            <Button Command="EditingCommands.ToggleUnderline" CommandTarget="{Binding Element}">
+                <TextBlock Text="U" TextDecorations="Underline"/>
+            </Button>
+            <Button Click="ToggleStrikethrough_Click">
+                <TextBlock Text="abc" TextDecorations="Strikethrough"/>
+            </Button>
+            <Separator/>
+            <Button Click="PickColor_Click" ToolTip="Text Color">
+                <Border Width="16" Height="16" Background="{Binding ForegroundBrush}" BorderBrush="Black" BorderThickness="1"/>
+            </Button>
+            <Separator/>
+            <Button Command="EditingCommands.AlignLeft" CommandTarget="{Binding Element}" Content="L"/>
+            <Button Command="EditingCommands.AlignCenter" CommandTarget="{Binding Element}" Content="C"/>
+            <Button Command="EditingCommands.AlignRight" CommandTarget="{Binding Element}" Content="R"/>
+            <Button Command="EditingCommands.AlignJustify" CommandTarget="{Binding Element}" Content="J"/>
+            <Separator/>
+            <Button Command="EditingCommands.ToggleBullets" CommandTarget="{Binding Element}" Content="•"/>
+            <Button Command="EditingCommands.ToggleNumbering" CommandTarget="{Binding Element}" Content="1."/>
+            <Separator/>
+            <Button Click="InsertImage_Click">
+                <TextBlock FontFamily="Segoe MDL2 Assets" Text="&#xE8B9;" FontSize="16"/>
+            </Button>
+        </ToolBar>
         <Grid>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition/>
@@ -105,11 +138,7 @@
                         <local:Ruler x:Name="RulerH" Grid.Row="0" Grid.Column="1" Height="20" Orientation="Horizontal" Units="{Binding Units}"/>
                         <local:Ruler x:Name="RulerV" Grid.Row="1" Grid.Column="0" Width="20" Orientation="Vertical" Units="{Binding Units}"/>
                         <Border Grid.Row="1" Grid.Column="1" Width="{Binding CardWidth}" Height="{Binding CardHeight}" CornerRadius="24" BorderBrush="#FFCCD1D8" BorderThickness="2" Background="{StaticResource CheckerBrush}">
-                            <Canvas x:Name="CardCanvas" Width="{Binding CardWidth}" Height="{Binding CardHeight}" Background="Transparent" Focusable="True"
-              MouseLeftButtonDown="CardCanvas_MouseLeftButtonDown"
-              MouseMove="CardCanvas_MouseMove"
-              MouseLeftButtonUp="CardCanvas_MouseLeftButtonUp"
-              MouseLeave="CardCanvas_MouseLeave">
+                            <Canvas x:Name="CardCanvas" Width="{Binding CardWidth}" Height="{Binding CardHeight}" Background="Transparent" Focusable="True">
                                 <Line x:Name="GuideH" Stroke="#660078D7" StrokeThickness="1.5" Visibility="Collapsed"/>
                                 <Line x:Name="GuideV" Stroke="#660078D7" StrokeThickness="1.5" Visibility="Collapsed"/>
                                 <Rectangle x:Name="Marquee" Stroke="#770078D7" StrokeDashArray="3,2" Fill="#220078D7" Visibility="Collapsed"/>
@@ -167,53 +196,7 @@
                                     <TextBlock Text="Hidden" Grid.Row="6" Grid.Column="0" VerticalAlignment="Center"/>
                                     <CheckBox IsChecked="{Binding IsHidden, UpdateSourceTrigger=PropertyChanged}" Grid.Row="6" Grid.Column="1" IsEnabled="{Binding Element, Converter={StaticResource NullToBoolInverse}}"/>
                                 </Grid>
-                                <Grid Visibility="{Binding IsText, Converter={StaticResource BoolToVis}}" Margin="0,10,0,0">
-                                    <Grid.RowDefinitions>
-                                        <RowDefinition Height="Auto"/>
-                                        <RowDefinition Height="Auto"/>
-                                        <RowDefinition Height="Auto"/>
-                                        <RowDefinition Height="Auto"/>
-                                        <RowDefinition Height="Auto"/>
-                                        <RowDefinition Height="Auto"/>
-                                    </Grid.RowDefinitions>
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="110"/>
-                                        <ColumnDefinition/>
-                                    </Grid.ColumnDefinitions>
-                                    <TextBlock Text="Text" Grid.Row="0" Grid.Column="0" VerticalAlignment="Center"/>
-                                    <RichTextBox x:Name="InspectorRtb" Grid.Row="0" Grid.Column="1" AcceptsReturn="True" TextChanged="InspectorRtb_TextChanged"/>
-                                    <TextBlock Text="Font Size" Grid.Row="1" Grid.Column="0" VerticalAlignment="Center"/>
-                                    <TextBox Text="{Binding FontSize, UpdateSourceTrigger=PropertyChanged, StringFormat=F0}" Grid.Row="1" Grid.Column="1"/>
-                                    <TextBlock Text="Font Family" Grid.Row="2" Grid.Column="0" VerticalAlignment="Center"/>
-                                    <ComboBox ItemsSource="{Binding FontFamilies}" SelectedItem="{Binding FontFamily, UpdateSourceTrigger=PropertyChanged}" Grid.Row="2" Grid.Column="1">
-                                        <ComboBox.ItemTemplate>
-                                            <DataTemplate>
-                                                <TextBlock Text="{Binding Source}" FontFamily="{Binding}"/>
-                                            </DataTemplate>
-                                        </ComboBox.ItemTemplate>
-                                    </ComboBox>
-                                    <TextBlock Text="Font Style" Grid.Row="3" Grid.Column="0" VerticalAlignment="Center"/>
-                                    <ComboBox SelectedItem="{Binding FontStyleOption, UpdateSourceTrigger=PropertyChanged}" Grid.Row="3" Grid.Column="1">
-                                        <sys:String>None</sys:String>
-                                        <sys:String>Italic</sys:String>
-                                        <sys:String>Bold</sys:String>
-                                        <sys:String>Bold Italic</sys:String>
-                                    </ComboBox>
-                                    <TextBlock Text="Text Align" Grid.Row="4" Grid.Column="0" VerticalAlignment="Center"/>
-                                    <ComboBox SelectedItem="{Binding TextAlignment, UpdateSourceTrigger=PropertyChanged}" Grid.Row="4" Grid.Column="1">
-                                        <TextAlignment>Left</TextAlignment>
-                                        <TextAlignment>Center</TextAlignment>
-                                        <TextAlignment>Right</TextAlignment>
-                                        <TextAlignment>Justify</TextAlignment>
-                                    </ComboBox>
-                                    <TextBlock Text="Color" Grid.Row="5" Grid.Column="0" VerticalAlignment="Center"/>
-                                    <Button Grid.Row="5" Grid.Column="1" Width="120" Click="PickColor_Click">
-                                        <StackPanel Orientation="Horizontal">
-                                            <Border Width="16" Height="16" Background="{Binding ForegroundBrush}" BorderBrush="Black" BorderThickness="1"/>
-                                            <TextBlock Text="{Binding ForegroundHex}" Margin="6,0,0,0" VerticalAlignment="Center"/>
-                                        </StackPanel>
-                                    </Button>
-                                </Grid>
+                                
                                 <Grid Visibility="{Binding IsImage, Converter={StaticResource BoolToVis}}" Margin="0,10,0,0">
                                     <Grid.RowDefinitions>
                                         <RowDefinition Height="Auto"/>

--- a/CardCreator/MainWindow.xaml.cs
+++ b/CardCreator/MainWindow.xaml.cs
@@ -28,18 +28,21 @@ namespace CardCreator
 public partial class MainWindow : Window
 {
     public MainViewModel VM => (MainViewModel)DataContext;
-    private bool _updatingInspector;
     public MainWindow()
     {
         Resources["NullToBoolInverse"] = new NullToBoolInverseConverter();
         InitializeComponent();
+        CardCanvas.AddHandler(UIElement.MouseLeftButtonDownEvent,
+            new MouseButtonEventHandler(CardCanvas_MouseLeftButtonDown), true);
+        CardCanvas.AddHandler(UIElement.MouseMoveEvent,
+            new MouseEventHandler(CardCanvas_MouseMove), true);
+        CardCanvas.AddHandler(UIElement.MouseLeftButtonUpEvent,
+            new MouseButtonEventHandler(CardCanvas_MouseLeftButtonUp), true);
+        CardCanvas.AddHandler(UIElement.MouseLeaveEvent,
+            new MouseEventHandler(CardCanvas_MouseLeave), true);
         VM.AttachCanvas(CardCanvas, GuideH, GuideV, Marquee);
         Loaded += (_, __) => UpdateRulerOrigins();
         CardCanvas.SizeChanged += (_, __) => UpdateRulerOrigins();
-        VM.Inspector.PropertyChanged += Inspector_PropertyChanged;
-        _updatingInspector = true;
-        InspectorRtb.Document = CloneDocument(VM.Inspector.Document);
-        _updatingInspector = false;
     }
     private void CardCanvas_MouseLeftButtonDown(object s, MouseButtonEventArgs e) => VM.OnCanvasMouseLeftDown(e);
     private void CardCanvas_MouseMove(object s, MouseEventArgs e)
@@ -58,36 +61,7 @@ public partial class MainWindow : Window
         MarkerReadout.Text = string.Empty;
     }
 
-    private void Inspector_PropertyChanged(object? sender, PropertyChangedEventArgs e)
-    {
-        if (_updatingInspector) return;
-        if (string.IsNullOrEmpty(e.PropertyName) || e.PropertyName == nameof(SelectedElementViewModel.Document))
-        {
-            _updatingInspector = true;
-            InspectorRtb.Document = CloneDocument(VM.Inspector.Document);
-            _updatingInspector = false;
-        }
-    }
-
-    private void InspectorRtb_TextChanged(object s, TextChangedEventArgs e)
-    {
-        if (_updatingInspector) return;
-        _updatingInspector = true;
-        VM.Inspector.Document = CloneDocument(InspectorRtb.Document);
-        _updatingInspector = false;
-    }
-
-    private static FlowDocument CloneDocument(FlowDocument document)
-    {
-        var clone = new FlowDocument();
-        using var stream = new MemoryStream();
-        var range = new TextRange(document.ContentStart, document.ContentEnd);
-        range.Save(stream, DataFormats.XamlPackage);
-        stream.Position = 0;
-        var cloneRange = new TextRange(clone.ContentStart, clone.ContentEnd);
-        cloneRange.Load(stream, DataFormats.XamlPackage);
-        return clone;
-    }
+    
 
     private void UpdateRulerOrigins()
     {
@@ -132,6 +106,39 @@ public partial class MainWindow : Window
         dlg.Color = DrawingColor.FromArgb(c.A, c.R, c.G, c.B);
         if (dlg.ShowDialog() == WinForms.DialogResult.OK)
             VM.Inspector.ForegroundColor = Color.FromArgb(dlg.Color.A, dlg.Color.R, dlg.Color.G, dlg.Color.B);
+    }
+    private void ToggleStrikethrough_Click(object s, RoutedEventArgs e)
+    {
+        if (VM.Inspector.Element is not RichTextBox rtb)
+            return;
+        var sel = new TextRange(rtb.Selection.Start, rtb.Selection.End);
+        var current = sel.GetPropertyValue(Inline.TextDecorationsProperty);
+        bool has = current is TextDecorationCollection tdc &&
+                   tdc.Any(td => td.Location == TextDecorationLocation.Strikethrough);
+        sel.ApplyPropertyValue(Inline.TextDecorationsProperty,
+            has ? null : TextDecorations.Strikethrough);
+        rtb.Focus();
+    }
+    private void InsertImage_Click(object s, RoutedEventArgs e)
+    {
+        if (VM.Inspector.Element is not RichTextBox rtb)
+            return;
+        var dlg = new OpenFileDialog { Filter = "Images|*.jpg;*.jpeg;*.png" };
+        if (dlg.ShowDialog() != true)
+            return;
+        try
+        {
+            var bi = new BitmapImage();
+            bi.BeginInit();
+            bi.UriSource = new Uri(dlg.FileName);
+            bi.CacheOption = BitmapCacheOption.OnLoad;
+            bi.EndInit();
+            bi.Freeze();
+            var img = new Image { Source = bi };
+            _ = new InlineUIContainer(img, rtb.CaretPosition);
+            rtb.Focus();
+        }
+        catch { }
     }
     private void Window_KeyDown(object s, KeyEventArgs e) => VM.OnKeyDown(e);
 }
@@ -357,7 +364,11 @@ public class MainViewModel : INotifyPropertyChanged
                 ClearSelection();
             return;
         }
-        var container = FindAncestor<Grid>(e.OriginalSource as DependencyObject);
+        var source = e.OriginalSource as DependencyObject;
+        var rtb = FindAncestor<RichTextBox>(source);
+        if (rtb != null)
+            source = rtb;
+        var container = FindAncestor<Grid>(source);
         if (container != null && _canvas.Children.Contains(container))
         {
             if (e.OriginalSource is Thumb)
@@ -496,7 +507,8 @@ public class MainViewModel : INotifyPropertyChanged
         if (_canvas == null)
             return;
         var tb = new RichTextBox { FontSize = 28, Foreground = Brushes.Black,
-                                 RenderTransformOrigin = new Point(0.5, 0.5), IsHitTestVisible = false };
+                                 Background = Brushes.Transparent,
+                                 RenderTransformOrigin = new Point(0.5, 0.5) };
         tb.Document = new FlowDocument(new Paragraph(new Run("Text")));
         var container = CreateContainer(tb, 60, 60, 180, 60);
         tb.Width = 180;
@@ -556,10 +568,12 @@ public class MainViewModel : INotifyPropertyChanged
         container.Children.Add(MakeThumb(Cursors.SizeNWSE, HorizontalAlignment.Right, VerticalAlignment.Bottom, 1, 1));
     }
 
-    private Grid CreateContainer(FrameworkElement inner, double x, double y, double w, double h, bool useSnap = true)
-    {
-        var container = new Grid { Background = Brushes.Transparent, Width = w, Height = h };
+      private Grid CreateContainer(FrameworkElement inner, double x, double y, double w, double h, bool useSnap = true)
+      {
+          var container = new Grid { Background = Brushes.Transparent, Width = w, Height = h };
         container.Children.Add(inner);
+        if (inner is RichTextBox rtb)
+            rtb.TextChanged += CanvasRichTextBox_TextChanged;
         AttachContainerChrome(container);
         if (useSnap && SnapEnabled)
         {
@@ -569,6 +583,12 @@ public class MainViewModel : INotifyPropertyChanged
         Canvas.SetLeft(container, x);
         Canvas.SetTop(container, y);
         return container;
+      }
+
+    private void CanvasRichTextBox_TextChanged(object? sender, TextChangedEventArgs e)
+    {
+        if (Inspector.Element == sender)
+            Inspector.NotifyTextChanged();
     }
 
     private void ResizeFromCorner(Grid container, DragDeltaEventArgs e, int xDir, int yDir)
@@ -1407,7 +1427,9 @@ public class MainViewModel : INotifyPropertyChanged
         {
             if (from is T t)
                 return t;
-            from = VisualTreeHelper.GetParent(from);
+            from = from is Visual
+                ? VisualTreeHelper.GetParent(from)
+                : LogicalTreeHelper.GetParent(from);
         }
         return null;
     }

--- a/CardCreator/Models/SelectedElementViewModel.cs
+++ b/CardCreator/Models/SelectedElementViewModel.cs
@@ -132,9 +132,11 @@ namespace CardCreator.Models {
         }
       }
     }
+    public void NotifyTextChanged() => OnPropertyChanged(nameof(Text));
     public double FontSize { get=> (Element as RichTextBox)?.FontSize ?? 16; set{ if(Element is RichTextBox tb){ tb.FontSize=value; OnPropertyChanged(); } } }
 
     public IEnumerable<FontFamily> FontFamilies { get; } = Fonts.SystemFontFamilies.OrderBy(f => f.Source);
+    public IEnumerable<double> FontSizes { get; } = new double[] { 8, 9, 10, 11, 12, 14, 16, 18, 20, 24, 28, 32, 36, 48, 72 };
     public FontFamily FontFamily {
       get => (Element as RichTextBox)?.FontFamily ?? Fonts.SystemFontFamilies.First();
       set { if (Element is RichTextBox tb) { tb.FontFamily = value; OnPropertyChanged(); } }

--- a/CardCreator/Services/TemplateSerializer.cs
+++ b/CardCreator/Services/TemplateSerializer.cs
@@ -65,7 +65,7 @@ namespace CardCreator.Services {
           if(item.Hidden==true) img.Visibility=Visibility.Hidden;
           inner=img;
         } else {
-          var rtb=new RichTextBox{ FontSize=item.FontSize??28, IsHitTestVisible=false };
+          var rtb=new RichTextBox{ FontSize=item.FontSize??28, Background=Brushes.Transparent };
           if(!string.IsNullOrWhiteSpace(item.Text)){
             try{ rtb.Document=(FlowDocument)XamlReader.Parse(item.Text); }
             catch{ rtb.Document=new FlowDocument(new Paragraph(new Run(item.Text))); }
@@ -76,6 +76,7 @@ namespace CardCreator.Services {
           if(!string.IsNullOrWhiteSpace(item.TextAlignment) && Enum.TryParse<TextAlignment>(item.TextAlignment, out var ta)) rtb.Document.TextAlignment=ta;
           if(!string.IsNullOrWhiteSpace(item.ForegroundHex)){ try{ rtb.Foreground=new SolidColorBrush((Color)ColorConverter.ConvertFromString(item.ForegroundHex!)); }catch{} }
           if(item.Hidden==true) rtb.Visibility=Visibility.Hidden;
+          rtb.IsHitTestVisible=true;
           inner=rtb;
         }
         if(!string.IsNullOrWhiteSpace(item.ControlName)) inner.Name=item.ControlName;
@@ -97,7 +98,7 @@ namespace CardCreator.Services {
       if(obj!=null){
         canvas.Children.Clear();
         foreach(UIElement child in obj.Children){
-          if(child is RichTextBox rtb) rtb.IsHitTestVisible=false;
+          if(child is RichTextBox rtb){ rtb.IsHitTestVisible=true; rtb.Background=Brushes.Transparent; }
           canvas.Children.Add(child);
         }
         model.CardWidth=obj.Width;
@@ -130,7 +131,7 @@ namespace CardCreator.Services {
             " FontWeight=\""+(rtb.FontWeight==FontWeights.Bold?"Bold":"Normal")+"\""+
             " FontStyle=\""+(rtb.FontStyle==FontStyles.Italic?"Italic":"Normal")+"\""+
             " Foreground=\""+color+"\""+
-            " Width=\""+g.Width+"\" Height=\""+g.Height+"\" Canvas.Left=\""+x+"\" Canvas.Top=\""+y+"\" IsHitTestVisible=\"False\""+tagAttr;
+            " Width=\""+g.Width+"\" Height=\""+g.Height+"\" Canvas.Left=\""+x+"\" Canvas.Top=\""+y+"\""+tagAttr;
           if(rtb.Visibility!=Visibility.Visible) attrs+=" Visibility=\""+rtb.Visibility+"\"";
           sb.AppendLine("  <RichTextBox"+attrs+">");
           var angle=GetRotation(inner);


### PR DESCRIPTION
## Summary
- show each font in its own style and offer common sizes with editable font size list
- implement manual strikethrough and transparent backgrounds for editable text boxes
- allow dragging selected RichTextBox items and keep templates hit-testable when loading
- resolve RichTextBox selection errors by defaulting to the text box when clicking inside its document
- add toolbar button to insert images into rich text
- propagate canvas RichTextBox edits to card data by raising inspector text updates

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-8.0`
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c442c34f908326a27befa99622e200