### PR TITLE
Add toolbar for editing rich text

### DIFF
--- a/CardCreator/MainWindow.xaml
+++ b/CardCreator/MainWindow.xaml
@@ -1,9 +1,7 @@
-<Window x:Class="CardCreator.MainWindow"
+ <Window x:Class="CardCreator.MainWindow"
  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
- xmlns:sys="clr-namespace:System;assembly=mscorlib"
  xmlns:local="clr-namespace:CardCreator"
- xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
  Title="Card Creator" Height="820" Width="1320"
  Background="#FFF9F9FB" KeyDown="Window_KeyDown">
     <Window.Resources>
@@ -86,6 +84,41 @@
                 <MenuItem Header="Show _Guidelines" IsCheckable="True" Visibility="Collapsed" IsChecked="{Binding GuidelinesEnabled}"/>
             </MenuItem>
         </Menu>
+        <ToolBar DockPanel.Dock="Top" DataContext="{Binding Inspector}" IsEnabled="{Binding IsText}">
+            <ComboBox x:Name="FontFamilyCombo" Width="170" ItemsSource="{Binding FontFamilies}" SelectionChanged="FontFamilyCombo_SelectionChanged">
+                <ComboBox.ItemTemplate>
+                    <DataTemplate>
+                        <TextBlock Text="{Binding Source}" FontFamily="{Binding}"/>
+                    </DataTemplate>
+                </ComboBox.ItemTemplate>
+            </ComboBox>
+            <ComboBox x:Name="FontSizeCombo" Width="60" IsEditable="True" ItemsSource="{Binding FontSizes}" SelectionChanged="FontSizeCombo_SelectionChanged" LostFocus="FontSizeCombo_LostFocus" KeyDown="FontSizeCombo_KeyDown"/>
+            <Separator/>
+            <Button Command="EditingCommands.ToggleBold" CommandTarget="{Binding Element}" FontWeight="Bold" Content="B"/>
+            <Button Command="EditingCommands.ToggleItalic" CommandTarget="{Binding Element}" FontStyle="Italic" Content="I"/>
+            <Button Command="EditingCommands.ToggleUnderline" CommandTarget="{Binding Element}">
+                <TextBlock Text="U" TextDecorations="Underline"/>
+            </Button>
+            <Button Click="ToggleStrikethrough_Click">
+                <TextBlock Text="abc" TextDecorations="Strikethrough"/>
+            </Button>
+            <Separator/>
+            <Button Click="PickColor_Click" ToolTip="Text Color">
+                <Border x:Name="ForegroundPreview" Width="16" Height="16" Background="Black" BorderBrush="Black" BorderThickness="1"/>
+            </Button>
+            <Separator/>
+            <Button Command="EditingCommands.AlignLeft" CommandTarget="{Binding Element}" Content="L"/>
+            <Button Command="EditingCommands.AlignCenter" CommandTarget="{Binding Element}" Content="C"/>
+            <Button Command="EditingCommands.AlignRight" CommandTarget="{Binding Element}" Content="R"/>
+            <Button Command="EditingCommands.AlignJustify" CommandTarget="{Binding Element}" Content="J"/>
+            <Separator/>
+            <Button Command="EditingCommands.ToggleBullets" CommandTarget="{Binding Element}" Content="•"/>
+            <Button Command="EditingCommands.ToggleNumbering" CommandTarget="{Binding Element}" Content="1."/>
+            <Separator/>
+            <Button Click="InsertImage_Click">
+                <TextBlock FontFamily="Segoe MDL2 Assets" Text="&#xE8B9;" FontSize="16"/>
+            </Button>
+        </ToolBar>
         <Grid>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition/>
@@ -105,11 +138,7 @@
                         <local:Ruler x:Name="RulerH" Grid.Row="0" Grid.Column="1" Height="20" Orientation="Horizontal" Units="{Binding Units}"/>
                         <local:Ruler x:Name="RulerV" Grid.Row="1" Grid.Column="0" Width="20" Orientation="Vertical" Units="{Binding Units}"/>
                         <Border Grid.Row="1" Grid.Column="1" Width="{Binding CardWidth}" Height="{Binding CardHeight}" CornerRadius="24" BorderBrush="#FFCCD1D8" BorderThickness="2" Background="{StaticResource CheckerBrush}">
-                            <Canvas x:Name="CardCanvas" Width="{Binding CardWidth}" Height="{Binding CardHeight}" Background="Transparent" Focusable="True"
-              MouseLeftButtonDown="CardCanvas_MouseLeftButtonDown"
-              MouseMove="CardCanvas_MouseMove"
-              MouseLeftButtonUp="CardCanvas_MouseLeftButtonUp"
-              MouseLeave="CardCanvas_MouseLeave">
+                            <Canvas x:Name="CardCanvas" Width="{Binding CardWidth}" Height="{Binding CardHeight}" Background="Transparent" Focusable="True">
                                 <Line x:Name="GuideH" Stroke="#660078D7" StrokeThickness="1.5" Visibility="Collapsed"/>
                                 <Line x:Name="GuideV" Stroke="#660078D7" StrokeThickness="1.5" Visibility="Collapsed"/>
                                 <Rectangle x:Name="Marquee" Stroke="#770078D7" StrokeDashArray="3,2" Fill="#220078D7" Visibility="Collapsed"/>
@@ -167,53 +196,7 @@
                                     <TextBlock Text="Hidden" Grid.Row="6" Grid.Column="0" VerticalAlignment="Center"/>
                                     <CheckBox IsChecked="{Binding IsHidden, UpdateSourceTrigger=PropertyChanged}" Grid.Row="6" Grid.Column="1" IsEnabled="{Binding Element, Converter={StaticResource NullToBoolInverse}}"/>
                                 </Grid>
-                                <Grid Visibility="{Binding IsText, Converter={StaticResource BoolToVis}}" Margin="0,10,0,0">
-                                    <Grid.RowDefinitions>
-                                        <RowDefinition Height="Auto"/>
-                                        <RowDefinition Height="Auto"/>
-                                        <RowDefinition Height="Auto"/>
-                                        <RowDefinition Height="Auto"/>
-                                        <RowDefinition Height="Auto"/>
-                                        <RowDefinition Height="Auto"/>
-                                    </Grid.RowDefinitions>
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="110"/>
-                                        <ColumnDefinition/>
-                                    </Grid.ColumnDefinitions>
-                                    <TextBlock Text="Text" Grid.Row="0" Grid.Column="0" VerticalAlignment="Center"/>
-                                    <RichTextBox x:Name="InspectorRtb" Grid.Row="0" Grid.Column="1" AcceptsReturn="True" TextChanged="InspectorRtb_TextChanged"/>
-                                    <TextBlock Text="Font Size" Grid.Row="1" Grid.Column="0" VerticalAlignment="Center"/>
-                                    <TextBox Text="{Binding FontSize, UpdateSourceTrigger=PropertyChanged, StringFormat=F0}" Grid.Row="1" Grid.Column="1"/>
-                                    <TextBlock Text="Font Family" Grid.Row="2" Grid.Column="0" VerticalAlignment="Center"/>
-                                    <ComboBox ItemsSource="{Binding FontFamilies}" SelectedItem="{Binding FontFamily, UpdateSourceTrigger=PropertyChanged}" Grid.Row="2" Grid.Column="1">
-                                        <ComboBox.ItemTemplate>
-                                            <DataTemplate>
-                                                <TextBlock Text="{Binding Source}" FontFamily="{Binding}"/>
-                                            </DataTemplate>
-                                        </ComboBox.ItemTemplate>
-                                    </ComboBox>
-                                    <TextBlock Text="Font Style" Grid.Row="3" Grid.Column="0" VerticalAlignment="Center"/>
-                                    <ComboBox SelectedItem="{Binding FontStyleOption, UpdateSourceTrigger=PropertyChanged}" Grid.Row="3" Grid.Column="1">
-                                        <sys:String>None</sys:String>
-                                        <sys:String>Italic</sys:String>
-                                        <sys:String>Bold</sys:String>
-                                        <sys:String>Bold Italic</sys:String>
-                                    </ComboBox>
-                                    <TextBlock Text="Text Align" Grid.Row="4" Grid.Column="0" VerticalAlignment="Center"/>
-                                    <ComboBox SelectedItem="{Binding TextAlignment, UpdateSourceTrigger=PropertyChanged}" Grid.Row="4" Grid.Column="1">
-                                        <TextAlignment>Left</TextAlignment>
-                                        <TextAlignment>Center</TextAlignment>
-                                        <TextAlignment>Right</TextAlignment>
-                                        <TextAlignment>Justify</TextAlignment>
-                                    </ComboBox>
-                                    <TextBlock Text="Color" Grid.Row="5" Grid.Column="0" VerticalAlignment="Center"/>
-                                    <Button Grid.Row="5" Grid.Column="1" Width="120" Click="PickColor_Click">
-                                        <StackPanel Orientation="Horizontal">
-                                            <Border Width="16" Height="16" Background="{Binding ForegroundBrush}" BorderBrush="Black" BorderThickness="1"/>
-                                            <TextBlock Text="{Binding ForegroundHex}" Margin="6,0,0,0" VerticalAlignment="Center"/>
-                                        </StackPanel>
-                                    </Button>
-                                </Grid>
+                                
                                 <Grid Visibility="{Binding IsImage, Converter={StaticResource BoolToVis}}" Margin="0,10,0,0">
                                     <Grid.RowDefinitions>
                                         <RowDefinition Height="Auto"/>

--- a/CardCreator/MainWindow.xaml.cs
+++ b/CardCreator/MainWindow.xaml.cs
@@ -28,18 +28,22 @@ namespace CardCreator
 public partial class MainWindow : Window
 {
     public MainViewModel VM => (MainViewModel)DataContext;
-    private bool _updatingInspector;
     public MainWindow()
     {
         Resources["NullToBoolInverse"] = new NullToBoolInverseConverter();
         InitializeComponent();
+        CardCanvas.AddHandler(UIElement.MouseLeftButtonDownEvent,
+            new MouseButtonEventHandler(CardCanvas_MouseLeftButtonDown), true);
+        CardCanvas.AddHandler(UIElement.MouseMoveEvent,
+            new MouseEventHandler(CardCanvas_MouseMove), true);
+        CardCanvas.AddHandler(UIElement.MouseLeftButtonUpEvent,
+            new MouseButtonEventHandler(CardCanvas_MouseLeftButtonUp), true);
+        CardCanvas.AddHandler(UIElement.MouseLeaveEvent,
+            new MouseEventHandler(CardCanvas_MouseLeave), true);
         VM.AttachCanvas(CardCanvas, GuideH, GuideV, Marquee);
         Loaded += (_, __) => UpdateRulerOrigins();
         CardCanvas.SizeChanged += (_, __) => UpdateRulerOrigins();
         VM.Inspector.PropertyChanged += Inspector_PropertyChanged;
-        _updatingInspector = true;
-        InspectorRtb.Document = CloneDocument(VM.Inspector.Document);
-        _updatingInspector = false;
     }
     private void CardCanvas_MouseLeftButtonDown(object s, MouseButtonEventArgs e) => VM.OnCanvasMouseLeftDown(e);
     private void CardCanvas_MouseMove(object s, MouseEventArgs e)
@@ -60,34 +64,11 @@ public partial class MainWindow : Window
 
     private void Inspector_PropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
-        if (_updatingInspector) return;
-        if (string.IsNullOrEmpty(e.PropertyName) || e.PropertyName == nameof(SelectedElementViewModel.Document))
-        {
-            _updatingInspector = true;
-            InspectorRtb.Document = CloneDocument(VM.Inspector.Document);
-            _updatingInspector = false;
-        }
+        if (string.IsNullOrEmpty(e.PropertyName))
+            UpdateFontToolbarFormatting();
     }
 
-    private void InspectorRtb_TextChanged(object s, TextChangedEventArgs e)
-    {
-        if (_updatingInspector) return;
-        _updatingInspector = true;
-        VM.Inspector.Document = CloneDocument(InspectorRtb.Document);
-        _updatingInspector = false;
-    }
-
-    private static FlowDocument CloneDocument(FlowDocument document)
-    {
-        var clone = new FlowDocument();
-        using var stream = new MemoryStream();
-        var range = new TextRange(document.ContentStart, document.ContentEnd);
-        range.Save(stream, DataFormats.XamlPackage);
-        stream.Position = 0;
-        var cloneRange = new TextRange(clone.ContentStart, clone.ContentEnd);
-        cloneRange.Load(stream, DataFormats.XamlPackage);
-        return clone;
-    }
+    
 
     private void UpdateRulerOrigins()
     {
@@ -125,13 +106,126 @@ public partial class MainWindow : Window
     }
     private void PickColor_Click(object s, RoutedEventArgs e)
     {
-        if (VM.Inspector.Element is not RichTextBox)
+        if (VM.Inspector.Element is not RichTextBox rtb)
             return;
         var dlg = new WinForms.ColorDialog();
-        var c = VM.Inspector.ForegroundColor;
+        var c = GetSelectionColor(rtb);
         dlg.Color = DrawingColor.FromArgb(c.A, c.R, c.G, c.B);
         if (dlg.ShowDialog() == WinForms.DialogResult.OK)
-            VM.Inspector.ForegroundColor = Color.FromArgb(dlg.Color.A, dlg.Color.R, dlg.Color.G, dlg.Color.B);
+        {
+            var color = Color.FromArgb(dlg.Color.A, dlg.Color.R, dlg.Color.G, dlg.Color.B);
+            var sel = new TextRange(rtb.Selection.Start, rtb.Selection.End);
+            sel.ApplyPropertyValue(TextElement.ForegroundProperty, new SolidColorBrush(color));
+            UpdateFontToolbarFormatting();
+            VM.Inspector.NotifyTextChanged();
+        }
+    }
+    private void ToggleStrikethrough_Click(object s, RoutedEventArgs e)
+    {
+        if (VM.Inspector.Element is not RichTextBox rtb)
+            return;
+        var sel = new TextRange(rtb.Selection.Start, rtb.Selection.End);
+        var current = sel.GetPropertyValue(Inline.TextDecorationsProperty);
+        bool has = current is TextDecorationCollection tdc &&
+                   tdc.Any(td => td.Location == TextDecorationLocation.Strikethrough);
+        sel.ApplyPropertyValue(Inline.TextDecorationsProperty,
+            has ? null : TextDecorations.Strikethrough);
+        rtb.Focus();
+    }
+    private void InsertImage_Click(object s, RoutedEventArgs e)
+    {
+        if (VM.Inspector.Element is not RichTextBox rtb)
+            return;
+        var dlg = new OpenFileDialog { Filter = "Images|*.jpg;*.jpeg;*.png" };
+        if (dlg.ShowDialog() != true)
+            return;
+        try
+        {
+            var bi = new BitmapImage();
+            bi.BeginInit();
+            bi.UriSource = new Uri(dlg.FileName);
+            bi.CacheOption = BitmapCacheOption.OnLoad;
+            bi.EndInit();
+            bi.Freeze();
+            var img = new Image { Source = bi };
+            _ = new InlineUIContainer(img, rtb.CaretPosition);
+            rtb.Focus();
+        }
+        catch { }
+    }
+    private void FontFamilyCombo_SelectionChanged(object s, SelectionChangedEventArgs e)
+    {
+        if (VM.Inspector.Element is not RichTextBox rtb || FontFamilyCombo.SelectedItem is not FontFamily ff)
+            return;
+        var sel = new TextRange(rtb.Selection.Start, rtb.Selection.End);
+        sel.ApplyPropertyValue(TextElement.FontFamilyProperty, ff);
+        rtb.Focus();
+        UpdateFontToolbarFormatting();
+        VM.Inspector.NotifyTextChanged();
+    }
+    private void FontSizeCombo_SelectionChanged(object s, SelectionChangedEventArgs e) => ApplyFontSizeFromCombo();
+    private void FontSizeCombo_KeyDown(object s, KeyEventArgs e)
+    {
+        if (e.Key == Key.Enter)
+            ApplyFontSizeFromText();
+    }
+    private void FontSizeCombo_LostFocus(object s, RoutedEventArgs e) => ApplyFontSizeFromText();
+    private void ApplyFontSizeFromCombo()
+    {
+        if (VM.Inspector.Element is not RichTextBox rtb)
+            return;
+        if (FontSizeCombo.SelectedItem is double size)
+        {
+            var sel = new TextRange(rtb.Selection.Start, rtb.Selection.End);
+            sel.ApplyPropertyValue(TextElement.FontSizeProperty, size);
+            rtb.Focus();
+            UpdateFontToolbarFormatting();
+            VM.Inspector.NotifyTextChanged();
+        }
+    }
+    private void ApplyFontSizeFromText()
+    {
+        if (VM.Inspector.Element is not RichTextBox rtb)
+            return;
+        if (double.TryParse(FontSizeCombo.Text, NumberStyles.Number, CultureInfo.InvariantCulture, out var size))
+        {
+            var sel = new TextRange(rtb.Selection.Start, rtb.Selection.End);
+            sel.ApplyPropertyValue(TextElement.FontSizeProperty, size);
+            rtb.Focus();
+            UpdateFontToolbarFormatting();
+            VM.Inspector.NotifyTextChanged();
+        }
+    }
+    internal void UpdateFontToolbarFormatting()
+    {
+        if (VM.Inspector.Element is not RichTextBox rtb)
+        {
+            FontFamilyCombo.SelectedItem = null;
+            FontSizeCombo.Text = string.Empty;
+            ForegroundPreview.Background = Brushes.Black;
+            return;
+        }
+        var sel = rtb.Selection;
+        var ffObj = sel.GetPropertyValue(TextElement.FontFamilyProperty);
+        if (ffObj is FontFamily fam)
+            FontFamilyCombo.SelectedItem = fam;
+        else
+            FontFamilyCombo.SelectedItem = null;
+        var fsObj = sel.GetPropertyValue(TextElement.FontSizeProperty);
+        if (fsObj is double fs)
+            FontSizeCombo.Text = fs.ToString(CultureInfo.InvariantCulture);
+        else
+            FontSizeCombo.Text = rtb.FontSize.ToString(CultureInfo.InvariantCulture);
+        var colObj = sel.GetPropertyValue(TextElement.ForegroundProperty);
+        if (colObj is SolidColorBrush scb)
+            ForegroundPreview.Background = scb;
+        else
+            ForegroundPreview.Background = Brushes.Black;
+    }
+    private Color GetSelectionColor(RichTextBox rtb)
+    {
+        var obj = rtb.Selection.GetPropertyValue(TextElement.ForegroundProperty);
+        return obj is SolidColorBrush scb ? scb.Color : Colors.Black;
     }
     private void Window_KeyDown(object s, KeyEventArgs e) => VM.OnKeyDown(e);
 }
@@ -357,7 +451,11 @@ public class MainViewModel : INotifyPropertyChanged
                 ClearSelection();
             return;
         }
-        var container = FindAncestor<Grid>(e.OriginalSource as DependencyObject);
+        var source = e.OriginalSource as DependencyObject;
+        var rtb = FindAncestor<RichTextBox>(source);
+        if (rtb != null)
+            source = rtb;
+        var container = FindAncestor<Grid>(source);
         if (container != null && _canvas.Children.Contains(container))
         {
             if (e.OriginalSource is Thumb)
@@ -496,7 +594,8 @@ public class MainViewModel : INotifyPropertyChanged
         if (_canvas == null)
             return;
         var tb = new RichTextBox { FontSize = 28, Foreground = Brushes.Black,
-                                 RenderTransformOrigin = new Point(0.5, 0.5), IsHitTestVisible = false };
+                                 Background = Brushes.Transparent,
+                                 RenderTransformOrigin = new Point(0.5, 0.5) };
         tb.Document = new FlowDocument(new Paragraph(new Run("Text")));
         var container = CreateContainer(tb, 60, 60, 180, 60);
         tb.Width = 180;
@@ -520,6 +619,11 @@ public class MainViewModel : INotifyPropertyChanged
 
     private void AttachContainerChrome(Grid container)
     {
+        if (container.Children.Count > 0 && container.Children[0] is RichTextBox rtb)
+        {
+            rtb.TextChanged += CanvasRichTextBox_TextChanged;
+            rtb.SelectionChanged += CanvasRichTextBox_SelectionChanged;
+        }
         var selBorder = new Border
         {
             BorderBrush = new SolidColorBrush(Color.FromArgb(200, 0, 120, 215)),
@@ -556,10 +660,15 @@ public class MainViewModel : INotifyPropertyChanged
         container.Children.Add(MakeThumb(Cursors.SizeNWSE, HorizontalAlignment.Right, VerticalAlignment.Bottom, 1, 1));
     }
 
-    private Grid CreateContainer(FrameworkElement inner, double x, double y, double w, double h, bool useSnap = true)
-    {
-        var container = new Grid { Background = Brushes.Transparent, Width = w, Height = h };
+      private Grid CreateContainer(FrameworkElement inner, double x, double y, double w, double h, bool useSnap = true)
+      {
+          var container = new Grid { Background = Brushes.Transparent, Width = w, Height = h };
         container.Children.Add(inner);
+        if (inner is RichTextBox rtb)
+        {
+            rtb.TextChanged += CanvasRichTextBox_TextChanged;
+            rtb.SelectionChanged += CanvasRichTextBox_SelectionChanged;
+        }
         AttachContainerChrome(container);
         if (useSnap && SnapEnabled)
         {
@@ -569,6 +678,18 @@ public class MainViewModel : INotifyPropertyChanged
         Canvas.SetLeft(container, x);
         Canvas.SetTop(container, y);
         return container;
+      }
+
+    private void CanvasRichTextBox_TextChanged(object? sender, TextChangedEventArgs e)
+    {
+        if (Inspector.Element == sender)
+            Inspector.NotifyTextChanged();
+    }
+
+    private void CanvasRichTextBox_SelectionChanged(object? sender, RoutedEventArgs e)
+    {
+        if (Inspector.Element == sender && Application.Current.MainWindow is MainWindow mw)
+            mw.UpdateFontToolbarFormatting();
     }
 
     private void ResizeFromCorner(Grid container, DragDeltaEventArgs e, int xDir, int yDir)
@@ -791,6 +912,7 @@ public class MainViewModel : INotifyPropertyChanged
         var folderDlg = new WinForms.FolderBrowserDialog();
         if (folderDlg.ShowDialog() != WinForms.DialogResult.OK)
             return;
+        ClearSelection();
         string dir = folderDlg.SelectedPath;
         var prev = SelectedCard;
         for (int i = 0; i < Cards.Count; i++)
@@ -818,6 +940,7 @@ public class MainViewModel : INotifyPropertyChanged
                                            FileName = "Sheet", DefaultExt = _useJpeg ? ".jpg" : ".png" };
         if (fileDlg.ShowDialog() != true)
             return;
+        ClearSelection();
         int perSheet = _sheetColumns * _sheetRows;
         var images = new List<RenderTargetBitmap>();
         var prev = SelectedCard;
@@ -922,14 +1045,6 @@ public class MainViewModel : INotifyPropertyChanged
         if (el is RichTextBox tb)
         {
             try { field.Text = XamlWriter.Save(tb.Document); } catch { field.Text = string.Empty; }
-            field.FontSize = tb.FontSize;
-            field.FontFamily = tb.FontFamily.Source;
-            bool bold = tb.FontWeight == FontWeights.Bold;
-            bool italic = tb.FontStyle == FontStyles.Italic;
-            field.FontStyle = bold && italic ? "Bold Italic" : (bold ? "Bold" : (italic ? "Italic" : "None"));
-            field.TextAlignment = tb.Document.TextAlignment.ToString();
-            if (tb.Foreground is SolidColorBrush scb)
-                field.Foreground = $"#{scb.Color.R:X2}{scb.Color.G:X2}{scb.Color.B:X2}";
         }
         else if (el is Image img)
         {
@@ -955,48 +1070,6 @@ public class MainViewModel : INotifyPropertyChanged
                 try { tb.Document = (FlowDocument)XamlReader.Parse(field.Text); }
                 catch { tb.Document = new FlowDocument(new Paragraph(new Run(field.Text))); }
             }
-            if (field.FontSize.HasValue)
-                tb.FontSize = field.FontSize.Value;
-            if (field.FontFamily != null)
-                try
-                {
-                    tb.FontFamily = new FontFamily(field.FontFamily);
-                }
-                catch
-                {
-                }
-            if (field.FontStyle != null)
-            {
-                switch (field.FontStyle)
-                {
-                case "Italic":
-                    tb.FontStyle = FontStyles.Italic;
-                    tb.FontWeight = FontWeights.Normal;
-                    break;
-                case "Bold":
-                    tb.FontStyle = FontStyles.Normal;
-                    tb.FontWeight = FontWeights.Bold;
-                    break;
-                case "Bold Italic":
-                    tb.FontStyle = FontStyles.Italic;
-                    tb.FontWeight = FontWeights.Bold;
-                    break;
-                default:
-                    tb.FontStyle = FontStyles.Normal;
-                    tb.FontWeight = FontWeights.Normal;
-                    break;
-                }
-            }
-            if (field.TextAlignment != null && Enum.TryParse<TextAlignment>(field.TextAlignment, out var ta))
-                tb.Document.TextAlignment = ta;
-            if (field.Foreground != null)
-                try
-                {
-                    tb.Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString(field.Foreground));
-                }
-                catch
-                {
-                }
         }
         else if (el is Image img)
         {
@@ -1034,11 +1107,6 @@ public class MainViewModel : INotifyPropertyChanged
             if (c.type == "Text")
             {
                 headers.Add($"{c.name}.Text");
-                headers.Add($"{c.name}.FontSize");
-                headers.Add($"{c.name}.FontFamily");
-                headers.Add($"{c.name}.FontStyle");
-                headers.Add($"{c.name}.TextAlignment");
-                headers.Add($"{c.name}.Foreground");
                 headers.Add($"{c.name}.Hidden");
             }
             else if (c.type == "Image")
@@ -1058,11 +1126,6 @@ public class MainViewModel : INotifyPropertyChanged
                 if (c.type == "Text")
                 {
                     values.Add(CsvEscape(field?.Text));
-                    values.Add(CsvEscape(field?.FontSize?.ToString()));
-                    values.Add(CsvEscape(field?.FontFamily));
-                    values.Add(CsvEscape(field?.FontStyle));
-                    values.Add(CsvEscape(field?.TextAlignment));
-                    values.Add(CsvEscape(field?.Foreground));
                     values.Add(CsvEscape((field?.Hidden ?? false).ToString()));
                 }
                 else if (c.type == "Image")
@@ -1116,22 +1179,6 @@ public class MainViewModel : INotifyPropertyChanged
                 {
                 case "Text":
                     field.Text = val;
-                    break;
-                case "FontSize":
-                    if (double.TryParse(val, out var fs))
-                        field.FontSize = fs;
-                    break;
-                case "FontFamily":
-                    field.FontFamily = val;
-                    break;
-                case "FontStyle":
-                    field.FontStyle = val;
-                    break;
-                case "TextAlignment":
-                    field.TextAlignment = val;
-                    break;
-                case "Foreground":
-                    field.Foreground = val;
                     break;
                 case "Source":
                     field.Source = val;
@@ -1228,11 +1275,6 @@ public class MainViewModel : INotifyPropertyChanged
         switch (e.PropertyName)
         {
         case nameof(SelectedElementViewModel.Text):
-        case nameof(SelectedElementViewModel.FontSize):
-        case nameof(SelectedElementViewModel.FontFamily):
-        case nameof(SelectedElementViewModel.FontStyleOption):
-        case nameof(SelectedElementViewModel.TextAlignment):
-        case nameof(SelectedElementViewModel.ForegroundColor):
         case nameof(SelectedElementViewModel.ImageSourcePath):
         case nameof(SelectedElementViewModel.ImageStretch):
         case nameof(SelectedElementViewModel.IsHidden):
@@ -1407,7 +1449,9 @@ public class MainViewModel : INotifyPropertyChanged
         {
             if (from is T t)
                 return t;
-            from = VisualTreeHelper.GetParent(from);
+            from = from is Visual
+                ? VisualTreeHelper.GetParent(from)
+                : LogicalTreeHelper.GetParent(from);
         }
         return null;
     }

--- a/CardCreator/Models/CardData.cs
+++ b/CardCreator/Models/CardData.cs
@@ -8,11 +8,6 @@ namespace CardCreator.Models {
   }
   public class CardField {
     public string? Text {get;set;}
-    public double? FontSize {get;set;}
-    public string? FontFamily {get;set;}
-    public string? FontStyle {get;set;}
-    public string? TextAlignment {get;set;}
-    public string? Foreground {get;set;}
     public string? Source {get;set;}
     public string? Stretch {get;set;}
     public bool? Hidden {get;set;}

--- a/CardCreator/Models/SelectedElementViewModel.cs
+++ b/CardCreator/Models/SelectedElementViewModel.cs
@@ -132,72 +132,9 @@ namespace CardCreator.Models {
         }
       }
     }
-    public double FontSize { get=> (Element as RichTextBox)?.FontSize ?? 16; set{ if(Element is RichTextBox tb){ tb.FontSize=value; OnPropertyChanged(); } } }
-
+    public void NotifyTextChanged() => OnPropertyChanged(nameof(Text));
     public IEnumerable<FontFamily> FontFamilies { get; } = Fonts.SystemFontFamilies.OrderBy(f => f.Source);
-    public FontFamily FontFamily {
-      get => (Element as RichTextBox)?.FontFamily ?? Fonts.SystemFontFamilies.First();
-      set { if (Element is RichTextBox tb) { tb.FontFamily = value; OnPropertyChanged(); } }
-    }
-
-    public string FontStyleOption {
-      get {
-        if (Element is RichTextBox tb) {
-          bool bold = tb.FontWeight == FontWeights.Bold;
-          bool italic = tb.FontStyle == FontStyles.Italic;
-          if (bold && italic) return "Bold Italic";
-          if (bold) return "Bold";
-          if (italic) return "Italic";
-          return "None";
-        }
-        return "None";
-      }
-      set {
-        if (Element is RichTextBox tb) {
-          switch (value) {
-            case "Italic":
-              tb.FontStyle = FontStyles.Italic;
-              tb.FontWeight = FontWeights.Normal;
-              break;
-            case "Bold":
-              tb.FontStyle = FontStyles.Normal;
-              tb.FontWeight = FontWeights.Bold;
-              break;
-            case "Bold Italic":
-              tb.FontStyle = FontStyles.Italic;
-              tb.FontWeight = FontWeights.Bold;
-              break;
-            default:
-              tb.FontStyle = FontStyles.Normal;
-              tb.FontWeight = FontWeights.Normal;
-              break;
-          }
-          OnPropertyChanged();
-        }
-      }
-    }
-    public TextAlignment TextAlignment { get => (Element as RichTextBox)?.Document.TextAlignment ?? TextAlignment.Left; set { if (Element is RichTextBox tb) { tb.Document.TextAlignment = value; OnPropertyChanged(); } } }
-    public Color ForegroundColor {
-      get {
-        if (Element is RichTextBox tb && tb.Foreground is SolidColorBrush scb) return scb.Color;
-        return Colors.Black;
-      }
-      set {
-        if (Element is RichTextBox tb) {
-          tb.Foreground = new SolidColorBrush(value);
-          OnPropertyChanged();
-          OnPropertyChanged(nameof(ForegroundHex));
-          OnPropertyChanged(nameof(ForegroundBrush));
-        }
-      }
-    }
-    public SolidColorBrush ForegroundBrush => new SolidColorBrush(ForegroundColor);
-    public string ForegroundHex {
-      get => $"#{ForegroundColor.R:X2}{ForegroundColor.G:X2}{ForegroundColor.B:X2}";
-      set {
-        try { ForegroundColor = (Color)ColorConverter.ConvertFromString(value); } catch {}
-      }
-    }
+    public IEnumerable<double> FontSizes { get; } = new double[] { 8, 9, 10, 11, 12, 14, 16, 18, 20, 24, 28, 32, 36, 48, 72 };
     public bool IsHidden {
       get {
         if (Element == null) return false;

--- a/CardCreator/Models/TemplateModel.cs
+++ b/CardCreator/Models/TemplateModel.cs
@@ -17,12 +17,6 @@ namespace CardCreator.Models {
     public int Z {get;set;}
     public string? ControlName {get;set;}
     public string? Text {get;set;}
-    public double? FontSize {get;set;}
-    public bool? Bold {get;set;}
-    public bool? Italic {get;set;}
-    public string? FontFamily {get;set;}
-    public string? TextAlignment {get;set;}
-    public string? ForegroundHex {get;set;}
     public string? Source {get;set;}
     public string? Stretch {get;set;}
     public bool? Hidden {get;set;}


### PR DESCRIPTION
## Summary
- show each font in its own style and offer common sizes with editable font size list
- implement manual strikethrough and transparent backgrounds for editable text boxes
- allow dragging selected RichTextBox items and keep templates hit-testable when loading
- resolve RichTextBox selection errors by defaulting to the text box when clicking inside its document
- add toolbar button to insert images into rich text
- propagate canvas RichTextBox edits to card data by raising inspector text updates
- apply font family, size, and color changes to the current selection and store formatting inside the FlowDocument
- move selection-change handler into the view model and expose toolbar formatting helper to correct class bracing
- clear element selection before exporting cards to images or sheets

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-8.0`
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c442c34f908326a27befa99622e200