### PR TITLE
Add toolbar for editing rich text

### DIFF
--- a/CardCreator/MainWindow.xaml
+++ b/CardCreator/MainWindow.xaml
@@ -1,9 +1,7 @@
-<Window x:Class="CardCreator.MainWindow"
+ <Window x:Class="CardCreator.MainWindow"
  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
- xmlns:sys="clr-namespace:System;assembly=mscorlib"
  xmlns:local="clr-namespace:CardCreator"
- xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
  Title="Card Creator" Height="820" Width="1320"
  Background="#FFF9F9FB" KeyDown="Window_KeyDown">
     <Window.Resources>
@@ -73,6 +71,7 @@
             <MenuItem Header="_View">
                 <MenuItem Header="_Snap" IsCheckable="True" IsChecked="{Binding SnapEnabled}"/>
                 <MenuItem Header="_Snap Grid Size">
+                    <MenuItem Header="1" IsCheckable="True" IsChecked="{Binding GridSize, Converter={StaticResource GridSizeToBool}, ConverterParameter=1}"/>
                     <MenuItem Header="5" IsCheckable="True" IsChecked="{Binding GridSize, Converter={StaticResource GridSizeToBool}, ConverterParameter=5}"/>
                     <MenuItem Header="10" IsCheckable="True" IsChecked="{Binding GridSize, Converter={StaticResource GridSizeToBool}, ConverterParameter=10}"/>
                     <MenuItem Header="20" IsCheckable="True" IsChecked="{Binding GridSize, Converter={StaticResource GridSizeToBool}, ConverterParameter=20}"/>
@@ -86,13 +85,48 @@
                 <MenuItem Header="Show _Guidelines" IsCheckable="True" Visibility="Collapsed" IsChecked="{Binding GuidelinesEnabled}"/>
             </MenuItem>
         </Menu>
+        <ToolBar DockPanel.Dock="Top" DataContext="{Binding Inspector}" IsEnabled="{Binding IsText}">
+            <ComboBox x:Name="FontFamilyCombo" Width="170" ItemsSource="{Binding FontFamilies}" SelectionChanged="FontFamilyCombo_SelectionChanged">
+                <ComboBox.ItemTemplate>
+                    <DataTemplate>
+                        <TextBlock Text="{Binding Source}" FontFamily="{Binding}"/>
+                    </DataTemplate>
+                </ComboBox.ItemTemplate>
+            </ComboBox>
+            <ComboBox x:Name="FontSizeCombo" Width="60" IsEditable="True" ItemsSource="{Binding FontSizes}" SelectionChanged="FontSizeCombo_SelectionChanged" LostFocus="FontSizeCombo_LostFocus" KeyDown="FontSizeCombo_KeyDown"/>
+            <Separator/>
+            <Button Command="EditingCommands.ToggleBold" CommandTarget="{Binding Element}" FontWeight="Bold" Content="B"/>
+            <Button Command="EditingCommands.ToggleItalic" CommandTarget="{Binding Element}" FontStyle="Italic" Content="I"/>
+            <Button Command="EditingCommands.ToggleUnderline" CommandTarget="{Binding Element}">
+                <TextBlock Text="U" TextDecorations="Underline"/>
+            </Button>
+            <Button Click="ToggleStrikethrough_Click">
+                <TextBlock Text="abc" TextDecorations="Strikethrough"/>
+            </Button>
+            <Separator/>
+            <Button Click="PickColor_Click" ToolTip="Text Color">
+                <Border x:Name="ForegroundPreview" Width="16" Height="16" Background="Black" BorderBrush="Black" BorderThickness="1"/>
+            </Button>
+            <Separator/>
+            <Button Command="EditingCommands.AlignLeft" CommandTarget="{Binding Element}" Content="L"/>
+            <Button Command="EditingCommands.AlignCenter" CommandTarget="{Binding Element}" Content="C"/>
+            <Button Command="EditingCommands.AlignRight" CommandTarget="{Binding Element}" Content="R"/>
+            <Button Command="EditingCommands.AlignJustify" CommandTarget="{Binding Element}" Content="J"/>
+            <Separator/>
+            <Button Command="EditingCommands.ToggleBullets" CommandTarget="{Binding Element}" Content="•"/>
+            <Button Command="EditingCommands.ToggleNumbering" CommandTarget="{Binding Element}" Content="1."/>
+            <Separator/>
+            <Button Click="InsertImage_Click">
+                <TextBlock FontFamily="Segoe MDL2 Assets" Text="&#xE8B9;" FontSize="16"/>
+            </Button>
+        </ToolBar>
         <Grid>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition/>
                 <ColumnDefinition Width="360"/>
             </Grid.ColumnDefinitions>
-            <Grid>
-                <ScrollViewer Grid.Column="0" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" Background="#FFEFF1F4">
+            <Grid Background="Transparent" MouseLeftButtonDown="Workspace_MouseLeftButtonDown">
+                <ScrollViewer Grid.Column="0" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" Background="#FFEFF1F4" MouseLeftButtonDown="Workspace_MouseLeftButtonDown">
                     <Grid>
                         <Grid.RowDefinitions>
                             <RowDefinition Height="20"/>
@@ -105,11 +139,7 @@
                         <local:Ruler x:Name="RulerH" Grid.Row="0" Grid.Column="1" Height="20" Orientation="Horizontal" Units="{Binding Units}"/>
                         <local:Ruler x:Name="RulerV" Grid.Row="1" Grid.Column="0" Width="20" Orientation="Vertical" Units="{Binding Units}"/>
                         <Border Grid.Row="1" Grid.Column="1" Width="{Binding CardWidth}" Height="{Binding CardHeight}" CornerRadius="24" BorderBrush="#FFCCD1D8" BorderThickness="2" Background="{StaticResource CheckerBrush}">
-                            <Canvas x:Name="CardCanvas" Width="{Binding CardWidth}" Height="{Binding CardHeight}" Background="Transparent" Focusable="True"
-              MouseLeftButtonDown="CardCanvas_MouseLeftButtonDown"
-              MouseMove="CardCanvas_MouseMove"
-              MouseLeftButtonUp="CardCanvas_MouseLeftButtonUp"
-              MouseLeave="CardCanvas_MouseLeave">
+                            <Canvas x:Name="CardCanvas" Width="{Binding CardWidth}" Height="{Binding CardHeight}" Background="Transparent" Focusable="True">
                                 <Line x:Name="GuideH" Stroke="#660078D7" StrokeThickness="1.5" Visibility="Collapsed"/>
                                 <Line x:Name="GuideV" Stroke="#660078D7" StrokeThickness="1.5" Visibility="Collapsed"/>
                                 <Rectangle x:Name="Marquee" Stroke="#770078D7" StrokeDashArray="3,2" Fill="#220078D7" Visibility="Collapsed"/>
@@ -167,53 +197,7 @@
                                     <TextBlock Text="Hidden" Grid.Row="6" Grid.Column="0" VerticalAlignment="Center"/>
                                     <CheckBox IsChecked="{Binding IsHidden, UpdateSourceTrigger=PropertyChanged}" Grid.Row="6" Grid.Column="1" IsEnabled="{Binding Element, Converter={StaticResource NullToBoolInverse}}"/>
                                 </Grid>
-                                <Grid Visibility="{Binding IsText, Converter={StaticResource BoolToVis}}" Margin="0,10,0,0">
-                                    <Grid.RowDefinitions>
-                                        <RowDefinition Height="Auto"/>
-                                        <RowDefinition Height="Auto"/>
-                                        <RowDefinition Height="Auto"/>
-                                        <RowDefinition Height="Auto"/>
-                                        <RowDefinition Height="Auto"/>
-                                        <RowDefinition Height="Auto"/>
-                                    </Grid.RowDefinitions>
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="110"/>
-                                        <ColumnDefinition/>
-                                    </Grid.ColumnDefinitions>
-                                    <TextBlock Text="Text" Grid.Row="0" Grid.Column="0" VerticalAlignment="Center"/>
-                                    <RichTextBox x:Name="InspectorRtb" Grid.Row="0" Grid.Column="1" AcceptsReturn="True" TextChanged="InspectorRtb_TextChanged"/>
-                                    <TextBlock Text="Font Size" Grid.Row="1" Grid.Column="0" VerticalAlignment="Center"/>
-                                    <TextBox Text="{Binding FontSize, UpdateSourceTrigger=PropertyChanged, StringFormat=F0}" Grid.Row="1" Grid.Column="1"/>
-                                    <TextBlock Text="Font Family" Grid.Row="2" Grid.Column="0" VerticalAlignment="Center"/>
-                                    <ComboBox ItemsSource="{Binding FontFamilies}" SelectedItem="{Binding FontFamily, UpdateSourceTrigger=PropertyChanged}" Grid.Row="2" Grid.Column="1">
-                                        <ComboBox.ItemTemplate>
-                                            <DataTemplate>
-                                                <TextBlock Text="{Binding Source}" FontFamily="{Binding}"/>
-                                            </DataTemplate>
-                                        </ComboBox.ItemTemplate>
-                                    </ComboBox>
-                                    <TextBlock Text="Font Style" Grid.Row="3" Grid.Column="0" VerticalAlignment="Center"/>
-                                    <ComboBox SelectedItem="{Binding FontStyleOption, UpdateSourceTrigger=PropertyChanged}" Grid.Row="3" Grid.Column="1">
-                                        <sys:String>None</sys:String>
-                                        <sys:String>Italic</sys:String>
-                                        <sys:String>Bold</sys:String>
-                                        <sys:String>Bold Italic</sys:String>
-                                    </ComboBox>
-                                    <TextBlock Text="Text Align" Grid.Row="4" Grid.Column="0" VerticalAlignment="Center"/>
-                                    <ComboBox SelectedItem="{Binding TextAlignment, UpdateSourceTrigger=PropertyChanged}" Grid.Row="4" Grid.Column="1">
-                                        <TextAlignment>Left</TextAlignment>
-                                        <TextAlignment>Center</TextAlignment>
-                                        <TextAlignment>Right</TextAlignment>
-                                        <TextAlignment>Justify</TextAlignment>
-                                    </ComboBox>
-                                    <TextBlock Text="Color" Grid.Row="5" Grid.Column="0" VerticalAlignment="Center"/>
-                                    <Button Grid.Row="5" Grid.Column="1" Width="120" Click="PickColor_Click">
-                                        <StackPanel Orientation="Horizontal">
-                                            <Border Width="16" Height="16" Background="{Binding ForegroundBrush}" BorderBrush="Black" BorderThickness="1"/>
-                                            <TextBlock Text="{Binding ForegroundHex}" Margin="6,0,0,0" VerticalAlignment="Center"/>
-                                        </StackPanel>
-                                    </Button>
-                                </Grid>
+                                
                                 <Grid Visibility="{Binding IsImage, Converter={StaticResource BoolToVis}}" Margin="0,10,0,0">
                                     <Grid.RowDefinitions>
                                         <RowDefinition Height="Auto"/>

--- a/CardCreator/MainWindow.xaml.cs
+++ b/CardCreator/MainWindow.xaml.cs
@@ -28,18 +28,22 @@ namespace CardCreator
 public partial class MainWindow : Window
 {
     public MainViewModel VM => (MainViewModel)DataContext;
-    private bool _updatingInspector;
     public MainWindow()
     {
         Resources["NullToBoolInverse"] = new NullToBoolInverseConverter();
         InitializeComponent();
+        CardCanvas.AddHandler(UIElement.MouseLeftButtonDownEvent,
+            new MouseButtonEventHandler(CardCanvas_MouseLeftButtonDown), true);
+        CardCanvas.AddHandler(UIElement.MouseMoveEvent,
+            new MouseEventHandler(CardCanvas_MouseMove), true);
+        CardCanvas.AddHandler(UIElement.MouseLeftButtonUpEvent,
+            new MouseButtonEventHandler(CardCanvas_MouseLeftButtonUp), true);
+        CardCanvas.AddHandler(UIElement.MouseLeaveEvent,
+            new MouseEventHandler(CardCanvas_MouseLeave), true);
         VM.AttachCanvas(CardCanvas, GuideH, GuideV, Marquee);
         Loaded += (_, __) => UpdateRulerOrigins();
         CardCanvas.SizeChanged += (_, __) => UpdateRulerOrigins();
         VM.Inspector.PropertyChanged += Inspector_PropertyChanged;
-        _updatingInspector = true;
-        InspectorRtb.Document = CloneDocument(VM.Inspector.Document);
-        _updatingInspector = false;
     }
     private void CardCanvas_MouseLeftButtonDown(object s, MouseButtonEventArgs e) => VM.OnCanvasMouseLeftDown(e);
     private void CardCanvas_MouseMove(object s, MouseEventArgs e)
@@ -60,34 +64,11 @@ public partial class MainWindow : Window
 
     private void Inspector_PropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
-        if (_updatingInspector) return;
-        if (string.IsNullOrEmpty(e.PropertyName) || e.PropertyName == nameof(SelectedElementViewModel.Document))
-        {
-            _updatingInspector = true;
-            InspectorRtb.Document = CloneDocument(VM.Inspector.Document);
-            _updatingInspector = false;
-        }
+        if (string.IsNullOrEmpty(e.PropertyName))
+            UpdateFontToolbarFormatting();
     }
 
-    private void InspectorRtb_TextChanged(object s, TextChangedEventArgs e)
-    {
-        if (_updatingInspector) return;
-        _updatingInspector = true;
-        VM.Inspector.Document = CloneDocument(InspectorRtb.Document);
-        _updatingInspector = false;
-    }
-
-    private static FlowDocument CloneDocument(FlowDocument document)
-    {
-        var clone = new FlowDocument();
-        using var stream = new MemoryStream();
-        var range = new TextRange(document.ContentStart, document.ContentEnd);
-        range.Save(stream, DataFormats.XamlPackage);
-        stream.Position = 0;
-        var cloneRange = new TextRange(clone.ContentStart, clone.ContentEnd);
-        cloneRange.Load(stream, DataFormats.XamlPackage);
-        return clone;
-    }
+    
 
     private void UpdateRulerOrigins()
     {
@@ -125,13 +106,132 @@ public partial class MainWindow : Window
     }
     private void PickColor_Click(object s, RoutedEventArgs e)
     {
-        if (VM.Inspector.Element is not RichTextBox)
+        if (VM.Inspector.Element is not RichTextBox rtb)
             return;
         var dlg = new WinForms.ColorDialog();
-        var c = VM.Inspector.ForegroundColor;
+        var c = GetSelectionColor(rtb);
         dlg.Color = DrawingColor.FromArgb(c.A, c.R, c.G, c.B);
         if (dlg.ShowDialog() == WinForms.DialogResult.OK)
-            VM.Inspector.ForegroundColor = Color.FromArgb(dlg.Color.A, dlg.Color.R, dlg.Color.G, dlg.Color.B);
+        {
+            var color = Color.FromArgb(dlg.Color.A, dlg.Color.R, dlg.Color.G, dlg.Color.B);
+            var sel = new TextRange(rtb.Selection.Start, rtb.Selection.End);
+            sel.ApplyPropertyValue(TextElement.ForegroundProperty, new SolidColorBrush(color));
+            UpdateFontToolbarFormatting();
+            VM.Inspector.NotifyTextChanged();
+        }
+    }
+    private void ToggleStrikethrough_Click(object s, RoutedEventArgs e)
+    {
+        if (VM.Inspector.Element is not RichTextBox rtb)
+            return;
+        var sel = new TextRange(rtb.Selection.Start, rtb.Selection.End);
+        var current = sel.GetPropertyValue(Inline.TextDecorationsProperty);
+        bool has = current is TextDecorationCollection tdc &&
+                   tdc.Any(td => td.Location == TextDecorationLocation.Strikethrough);
+        sel.ApplyPropertyValue(Inline.TextDecorationsProperty,
+            has ? null : TextDecorations.Strikethrough);
+        rtb.Focus();
+    }
+    private void InsertImage_Click(object s, RoutedEventArgs e)
+    {
+        if (VM.Inspector.Element is not RichTextBox rtb)
+            return;
+        var dlg = new OpenFileDialog { Filter = "Images|*.jpg;*.jpeg;*.png" };
+        if (dlg.ShowDialog() != true)
+            return;
+        try
+        {
+            var bi = new BitmapImage();
+            bi.BeginInit();
+            bi.UriSource = new Uri(dlg.FileName);
+            bi.CacheOption = BitmapCacheOption.OnLoad;
+            bi.EndInit();
+            bi.Freeze();
+            var img = new Image { Source = bi };
+            _ = new InlineUIContainer(img, rtb.CaretPosition);
+            rtb.Focus();
+        }
+        catch { }
+    }
+    private void FontFamilyCombo_SelectionChanged(object s, SelectionChangedEventArgs e)
+    {
+        if (VM.Inspector.Element is not RichTextBox rtb || FontFamilyCombo.SelectedItem is not FontFamily ff)
+            return;
+        var sel = new TextRange(rtb.Selection.Start, rtb.Selection.End);
+        sel.ApplyPropertyValue(TextElement.FontFamilyProperty, ff);
+        rtb.Focus();
+        UpdateFontToolbarFormatting();
+        VM.Inspector.NotifyTextChanged();
+    }
+    private void FontSizeCombo_SelectionChanged(object s, SelectionChangedEventArgs e) => ApplyFontSizeFromCombo();
+    private void FontSizeCombo_KeyDown(object s, KeyEventArgs e)
+    {
+        if (e.Key == Key.Enter)
+            ApplyFontSizeFromText();
+    }
+    private void FontSizeCombo_LostFocus(object s, RoutedEventArgs e) => ApplyFontSizeFromText();
+    private void ApplyFontSizeFromCombo()
+    {
+        if (VM.Inspector.Element is not RichTextBox rtb)
+            return;
+        if (FontSizeCombo.SelectedItem is double size)
+        {
+            var sel = new TextRange(rtb.Selection.Start, rtb.Selection.End);
+            sel.ApplyPropertyValue(TextElement.FontSizeProperty, size);
+            rtb.Focus();
+            UpdateFontToolbarFormatting();
+            VM.Inspector.NotifyTextChanged();
+        }
+    }
+    private void ApplyFontSizeFromText()
+    {
+        if (VM.Inspector.Element is not RichTextBox rtb)
+            return;
+        if (double.TryParse(FontSizeCombo.Text, NumberStyles.Number, CultureInfo.InvariantCulture, out var size))
+        {
+            var sel = new TextRange(rtb.Selection.Start, rtb.Selection.End);
+            sel.ApplyPropertyValue(TextElement.FontSizeProperty, size);
+            rtb.Focus();
+            UpdateFontToolbarFormatting();
+            VM.Inspector.NotifyTextChanged();
+        }
+    }
+    internal void UpdateFontToolbarFormatting()
+    {
+        if (VM.Inspector.Element is not RichTextBox rtb)
+        {
+            FontFamilyCombo.SelectedItem = null;
+            FontSizeCombo.Text = string.Empty;
+            ForegroundPreview.Background = Brushes.Black;
+            return;
+        }
+        var sel = rtb.Selection;
+        var ffObj = sel.GetPropertyValue(TextElement.FontFamilyProperty);
+        if (ffObj is FontFamily fam)
+            FontFamilyCombo.SelectedItem = fam;
+        else
+            FontFamilyCombo.SelectedItem = null;
+        var fsObj = sel.GetPropertyValue(TextElement.FontSizeProperty);
+        if (fsObj is double fs)
+            FontSizeCombo.Text = fs.ToString(CultureInfo.InvariantCulture);
+        else
+            FontSizeCombo.Text = rtb.FontSize.ToString(CultureInfo.InvariantCulture);
+        var colObj = sel.GetPropertyValue(TextElement.ForegroundProperty);
+        if (colObj is SolidColorBrush scb)
+            ForegroundPreview.Background = scb;
+        else
+            ForegroundPreview.Background = Brushes.Black;
+    }
+    private Color GetSelectionColor(RichTextBox rtb)
+    {
+        var obj = rtb.Selection.GetPropertyValue(TextElement.ForegroundProperty);
+        return obj is SolidColorBrush scb ? scb.Color : Colors.Black;
+    }
+    private void Workspace_MouseLeftButtonDown(object s, MouseButtonEventArgs e)
+    {
+        var source = e.OriginalSource as DependencyObject;
+        if (MainViewModel.FindAncestor<Canvas>(source) != CardCanvas)
+            VM.ClearSelection();
     }
     private void Window_KeyDown(object s, KeyEventArgs e) => VM.OnKeyDown(e);
 }
@@ -357,7 +457,11 @@ public class MainViewModel : INotifyPropertyChanged
                 ClearSelection();
             return;
         }
-        var container = FindAncestor<Grid>(e.OriginalSource as DependencyObject);
+        var source = e.OriginalSource as DependencyObject;
+        var rtb = FindAncestor<RichTextBox>(source);
+        if (rtb != null)
+            source = rtb;
+        var container = FindAncestor<Grid>(source);
         if (container != null && _canvas.Children.Contains(container))
         {
             if (e.OriginalSource is Thumb)
@@ -441,7 +545,18 @@ public class MainViewModel : INotifyPropertyChanged
 
     public void OnKeyDown(KeyEventArgs e)
     {
-        if (_canvas == null || _selected.Count == 0)
+        if (_canvas == null)
+            return;
+        if (e.Key == Key.Escape)
+        {
+            if (_selected.Count > 0)
+            {
+                ClearSelection();
+                e.Handled = true;
+            }
+            return;
+        }
+        if (_selected.Count == 0)
             return;
         if (e.Key == Key.Delete)
         {
@@ -495,8 +610,16 @@ public class MainViewModel : INotifyPropertyChanged
     {
         if (_canvas == null)
             return;
-        var tb = new RichTextBox { FontSize = 28, Foreground = Brushes.Black,
-                                 RenderTransformOrigin = new Point(0.5, 0.5), IsHitTestVisible = false };
+        var tb = new RichTextBox
+        {
+            FontSize = 28,
+            Foreground = Brushes.Black,
+            Background = Brushes.Transparent,
+            BorderBrush = null,
+            BorderThickness = new Thickness(0),
+            FocusVisualStyle = null,
+            RenderTransformOrigin = new Point(0.5, 0.5)
+        };
         tb.Document = new FlowDocument(new Paragraph(new Run("Text")));
         var container = CreateContainer(tb, 60, 60, 180, 60);
         tb.Width = 180;
@@ -520,6 +643,11 @@ public class MainViewModel : INotifyPropertyChanged
 
     private void AttachContainerChrome(Grid container)
     {
+        if (container.Children.Count > 0 && container.Children[0] is RichTextBox rtb)
+        {
+            rtb.TextChanged += CanvasRichTextBox_TextChanged;
+            rtb.SelectionChanged += CanvasRichTextBox_SelectionChanged;
+        }
         var selBorder = new Border
         {
             BorderBrush = new SolidColorBrush(Color.FromArgb(200, 0, 120, 215)),
@@ -556,10 +684,15 @@ public class MainViewModel : INotifyPropertyChanged
         container.Children.Add(MakeThumb(Cursors.SizeNWSE, HorizontalAlignment.Right, VerticalAlignment.Bottom, 1, 1));
     }
 
-    private Grid CreateContainer(FrameworkElement inner, double x, double y, double w, double h, bool useSnap = true)
-    {
-        var container = new Grid { Background = Brushes.Transparent, Width = w, Height = h };
+      private Grid CreateContainer(FrameworkElement inner, double x, double y, double w, double h, bool useSnap = true)
+      {
+          var container = new Grid { Background = Brushes.Transparent, Width = w, Height = h };
         container.Children.Add(inner);
+        if (inner is RichTextBox rtb)
+        {
+            rtb.TextChanged += CanvasRichTextBox_TextChanged;
+            rtb.SelectionChanged += CanvasRichTextBox_SelectionChanged;
+        }
         AttachContainerChrome(container);
         if (useSnap && SnapEnabled)
         {
@@ -569,6 +702,18 @@ public class MainViewModel : INotifyPropertyChanged
         Canvas.SetLeft(container, x);
         Canvas.SetTop(container, y);
         return container;
+      }
+
+    private void CanvasRichTextBox_TextChanged(object? sender, TextChangedEventArgs e)
+    {
+        if (Inspector.Element == sender)
+            Inspector.NotifyTextChanged();
+    }
+
+    private void CanvasRichTextBox_SelectionChanged(object? sender, RoutedEventArgs e)
+    {
+        if (Inspector.Element == sender && Application.Current.MainWindow is MainWindow mw)
+            mw.UpdateFontToolbarFormatting();
     }
 
     private void ResizeFromCorner(Grid container, DragDeltaEventArgs e, int xDir, int yDir)
@@ -686,7 +831,7 @@ public class MainViewModel : INotifyPropertyChanged
         UpdateSelectionVisuals();
         UpdateInspector();
     }
-    private void ClearSelection()
+    public void ClearSelection()
     {
         _selected.Clear();
         UpdateSelectionVisuals();
@@ -791,6 +936,7 @@ public class MainViewModel : INotifyPropertyChanged
         var folderDlg = new WinForms.FolderBrowserDialog();
         if (folderDlg.ShowDialog() != WinForms.DialogResult.OK)
             return;
+        ClearSelection();
         string dir = folderDlg.SelectedPath;
         var prev = SelectedCard;
         for (int i = 0; i < Cards.Count; i++)
@@ -818,6 +964,7 @@ public class MainViewModel : INotifyPropertyChanged
                                            FileName = "Sheet", DefaultExt = _useJpeg ? ".jpg" : ".png" };
         if (fileDlg.ShowDialog() != true)
             return;
+        ClearSelection();
         int perSheet = _sheetColumns * _sheetRows;
         var images = new List<RenderTargetBitmap>();
         var prev = SelectedCard;
@@ -922,14 +1069,6 @@ public class MainViewModel : INotifyPropertyChanged
         if (el is RichTextBox tb)
         {
             try { field.Text = XamlWriter.Save(tb.Document); } catch { field.Text = string.Empty; }
-            field.FontSize = tb.FontSize;
-            field.FontFamily = tb.FontFamily.Source;
-            bool bold = tb.FontWeight == FontWeights.Bold;
-            bool italic = tb.FontStyle == FontStyles.Italic;
-            field.FontStyle = bold && italic ? "Bold Italic" : (bold ? "Bold" : (italic ? "Italic" : "None"));
-            field.TextAlignment = tb.Document.TextAlignment.ToString();
-            if (tb.Foreground is SolidColorBrush scb)
-                field.Foreground = $"#{scb.Color.R:X2}{scb.Color.G:X2}{scb.Color.B:X2}";
         }
         else if (el is Image img)
         {
@@ -955,48 +1094,6 @@ public class MainViewModel : INotifyPropertyChanged
                 try { tb.Document = (FlowDocument)XamlReader.Parse(field.Text); }
                 catch { tb.Document = new FlowDocument(new Paragraph(new Run(field.Text))); }
             }
-            if (field.FontSize.HasValue)
-                tb.FontSize = field.FontSize.Value;
-            if (field.FontFamily != null)
-                try
-                {
-                    tb.FontFamily = new FontFamily(field.FontFamily);
-                }
-                catch
-                {
-                }
-            if (field.FontStyle != null)
-            {
-                switch (field.FontStyle)
-                {
-                case "Italic":
-                    tb.FontStyle = FontStyles.Italic;
-                    tb.FontWeight = FontWeights.Normal;
-                    break;
-                case "Bold":
-                    tb.FontStyle = FontStyles.Normal;
-                    tb.FontWeight = FontWeights.Bold;
-                    break;
-                case "Bold Italic":
-                    tb.FontStyle = FontStyles.Italic;
-                    tb.FontWeight = FontWeights.Bold;
-                    break;
-                default:
-                    tb.FontStyle = FontStyles.Normal;
-                    tb.FontWeight = FontWeights.Normal;
-                    break;
-                }
-            }
-            if (field.TextAlignment != null && Enum.TryParse<TextAlignment>(field.TextAlignment, out var ta))
-                tb.Document.TextAlignment = ta;
-            if (field.Foreground != null)
-                try
-                {
-                    tb.Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString(field.Foreground));
-                }
-                catch
-                {
-                }
         }
         else if (el is Image img)
         {
@@ -1034,11 +1131,6 @@ public class MainViewModel : INotifyPropertyChanged
             if (c.type == "Text")
             {
                 headers.Add($"{c.name}.Text");
-                headers.Add($"{c.name}.FontSize");
-                headers.Add($"{c.name}.FontFamily");
-                headers.Add($"{c.name}.FontStyle");
-                headers.Add($"{c.name}.TextAlignment");
-                headers.Add($"{c.name}.Foreground");
                 headers.Add($"{c.name}.Hidden");
             }
             else if (c.type == "Image")
@@ -1058,11 +1150,6 @@ public class MainViewModel : INotifyPropertyChanged
                 if (c.type == "Text")
                 {
                     values.Add(CsvEscape(field?.Text));
-                    values.Add(CsvEscape(field?.FontSize?.ToString()));
-                    values.Add(CsvEscape(field?.FontFamily));
-                    values.Add(CsvEscape(field?.FontStyle));
-                    values.Add(CsvEscape(field?.TextAlignment));
-                    values.Add(CsvEscape(field?.Foreground));
                     values.Add(CsvEscape((field?.Hidden ?? false).ToString()));
                 }
                 else if (c.type == "Image")
@@ -1116,22 +1203,6 @@ public class MainViewModel : INotifyPropertyChanged
                 {
                 case "Text":
                     field.Text = val;
-                    break;
-                case "FontSize":
-                    if (double.TryParse(val, out var fs))
-                        field.FontSize = fs;
-                    break;
-                case "FontFamily":
-                    field.FontFamily = val;
-                    break;
-                case "FontStyle":
-                    field.FontStyle = val;
-                    break;
-                case "TextAlignment":
-                    field.TextAlignment = val;
-                    break;
-                case "Foreground":
-                    field.Foreground = val;
                     break;
                 case "Source":
                     field.Source = val;
@@ -1228,11 +1299,6 @@ public class MainViewModel : INotifyPropertyChanged
         switch (e.PropertyName)
         {
         case nameof(SelectedElementViewModel.Text):
-        case nameof(SelectedElementViewModel.FontSize):
-        case nameof(SelectedElementViewModel.FontFamily):
-        case nameof(SelectedElementViewModel.FontStyleOption):
-        case nameof(SelectedElementViewModel.TextAlignment):
-        case nameof(SelectedElementViewModel.ForegroundColor):
         case nameof(SelectedElementViewModel.ImageSourcePath):
         case nameof(SelectedElementViewModel.ImageStretch):
         case nameof(SelectedElementViewModel.IsHidden):
@@ -1400,14 +1466,16 @@ public class MainViewModel : INotifyPropertyChanged
     }
 
     private double Snap(double v) => SnapEnabled ? Math.Round(v / _gridSize) * _gridSize : v;
-    private static T? FindAncestor<T>(DependencyObject? from)
+    internal static T? FindAncestor<T>(DependencyObject? from)
         where T : DependencyObject
     {
         while (from != null)
         {
             if (from is T t)
                 return t;
-            from = VisualTreeHelper.GetParent(from);
+            from = from is Visual
+                ? VisualTreeHelper.GetParent(from)
+                : LogicalTreeHelper.GetParent(from);
         }
         return null;
     }

--- a/CardCreator/Models/CardData.cs
+++ b/CardCreator/Models/CardData.cs
@@ -8,11 +8,6 @@ namespace CardCreator.Models {
   }
   public class CardField {
     public string? Text {get;set;}
-    public double? FontSize {get;set;}
-    public string? FontFamily {get;set;}
-    public string? FontStyle {get;set;}
-    public string? TextAlignment {get;set;}
-    public string? Foreground {get;set;}
     public string? Source {get;set;}
     public string? Stretch {get;set;}
     public bool? Hidden {get;set;}

--- a/CardCreator/Models/TemplateModel.cs
+++ b/CardCreator/Models/TemplateModel.cs
@@ -17,12 +17,6 @@ namespace CardCreator.Models {
     public int Z {get;set;}
     public string? ControlName {get;set;}
     public string? Text {get;set;}
-    public double? FontSize {get;set;}
-    public bool? Bold {get;set;}
-    public bool? Italic {get;set;}
-    public string? FontFamily {get;set;}
-    public string? TextAlignment {get;set;}
-    public string? ForegroundHex {get;set;}
     public string? Source {get;set;}
     public string? Stretch {get;set;}
     public bool? Hidden {get;set;}

--- a/CardCreator/Services/TemplateSerializer.cs
+++ b/CardCreator/Services/TemplateSerializer.cs
@@ -30,15 +30,8 @@ namespace CardCreator.Services {
         if(inner is RichTextBox rtb){
           item.Type="Text";
           try{ item.Text=XamlWriter.Save(rtb.Document); }catch{ item.Text=""; }
-          item.FontSize=rtb.FontSize; item.Bold=rtb.FontWeight==FontWeights.Bold;
-          item.Italic=rtb.FontStyle==FontStyles.Italic; item.TextAlignment=rtb.Document.TextAlignment.ToString();
-          item.FontFamily=rtb.FontFamily.Source;
-          if(rtb.Foreground is SolidColorBrush scb) item.ForegroundHex=$"#{scb.Color.R:X2}{scb.Color.G:X2}{scb.Color.B:X2}";
         } else if(inner is TextBlock tb){
-          item.Type="Text"; item.Text=XamlWriter.Save(new FlowDocument(new Paragraph(new Run(tb.Text??"")))); item.FontSize=tb.FontSize; item.Bold=tb.FontWeight==FontWeights.Bold;
-          item.Italic=tb.FontStyle==FontStyles.Italic; item.TextAlignment=tb.TextAlignment.ToString();
-          item.FontFamily=tb.FontFamily.Source;
-          if(tb.Foreground is SolidColorBrush scb) item.ForegroundHex=$"#{scb.Color.R:X2}{scb.Color.G:X2}{scb.Color.B:X2}";
+          item.Type="Text"; item.Text=XamlWriter.Save(new FlowDocument(new Paragraph(new Run(tb.Text??""))));
         } else if(inner is Image img){
           item.Type="Image"; item.Source=TryGetImageSource(img); item.Stretch=img.Stretch.ToString();
         }
@@ -65,17 +58,19 @@ namespace CardCreator.Services {
           if(item.Hidden==true) img.Visibility=Visibility.Hidden;
           inner=img;
         } else {
-          var rtb=new RichTextBox{ FontSize=item.FontSize??28, IsHitTestVisible=false };
+          var rtb=new RichTextBox{
+            FontSize=28,
+            Background=Brushes.Transparent,
+            BorderBrush=null,
+            BorderThickness=new Thickness(0),
+            FocusVisualStyle=null
+          };
           if(!string.IsNullOrWhiteSpace(item.Text)){
             try{ rtb.Document=(FlowDocument)XamlReader.Parse(item.Text); }
             catch{ rtb.Document=new FlowDocument(new Paragraph(new Run(item.Text))); }
           }
-          if(item.Bold==true) rtb.FontWeight=FontWeights.Bold;
-          if(item.Italic==true) rtb.FontStyle=FontStyles.Italic;
-          if(!string.IsNullOrWhiteSpace(item.FontFamily)) try{ rtb.FontFamily=new FontFamily(item.FontFamily); }catch{}
-          if(!string.IsNullOrWhiteSpace(item.TextAlignment) && Enum.TryParse<TextAlignment>(item.TextAlignment, out var ta)) rtb.Document.TextAlignment=ta;
-          if(!string.IsNullOrWhiteSpace(item.ForegroundHex)){ try{ rtb.Foreground=new SolidColorBrush((Color)ColorConverter.ConvertFromString(item.ForegroundHex!)); }catch{} }
           if(item.Hidden==true) rtb.Visibility=Visibility.Hidden;
+          rtb.IsHitTestVisible=true;
           inner=rtb;
         }
         if(!string.IsNullOrWhiteSpace(item.ControlName)) inner.Name=item.ControlName;
@@ -97,7 +92,13 @@ namespace CardCreator.Services {
       if(obj!=null){
         canvas.Children.Clear();
         foreach(UIElement child in obj.Children){
-          if(child is RichTextBox rtb) rtb.IsHitTestVisible=false;
+          if(child is RichTextBox rtb){
+            rtb.IsHitTestVisible=true;
+            rtb.Background=Brushes.Transparent;
+            rtb.BorderBrush=null;
+            rtb.BorderThickness=new Thickness(0);
+            rtb.FocusVisualStyle=null;
+          }
           canvas.Children.Add(child);
         }
         model.CardWidth=obj.Width;
@@ -123,14 +124,7 @@ namespace CardCreator.Services {
         string tagAttr="";
         if(inner.Tag is string tag && !string.IsNullOrWhiteSpace(tag)) tagAttr=" Tag=\""+XmlEscape(tag)+"\"";
         if(inner is RichTextBox rtb){
-          string color="#000000";
-          if(rtb.Foreground is SolidColorBrush scb) color=$"#{scb.Color.R:X2}{scb.Color.G:X2}{scb.Color.B:X2}";
-          var attrs=" FontSize=\""+rtb.FontSize+"\""+
-            " FontFamily=\""+XmlEscape(rtb.FontFamily.Source)+"\""+
-            " FontWeight=\""+(rtb.FontWeight==FontWeights.Bold?"Bold":"Normal")+"\""+
-            " FontStyle=\""+(rtb.FontStyle==FontStyles.Italic?"Italic":"Normal")+"\""+
-            " Foreground=\""+color+"\""+
-            " Width=\""+g.Width+"\" Height=\""+g.Height+"\" Canvas.Left=\""+x+"\" Canvas.Top=\""+y+"\" IsHitTestVisible=\"False\""+tagAttr;
+          var attrs=" Width=\""+g.Width+"\" Height=\""+g.Height+"\" Canvas.Left=\""+x+"\" Canvas.Top=\""+y+"\""+tagAttr;
           if(rtb.Visibility!=Visibility.Visible) attrs+=" Visibility=\""+rtb.Visibility+"\"";
           sb.AppendLine("  <RichTextBox"+attrs+">");
           var angle=GetRotation(inner);

--- a/CardCreator/obj/CardCreator.csproj.nuget.dgspec.json
+++ b/CardCreator/obj/CardCreator.csproj.nuget.dgspec.json
@@ -1,32 +1,25 @@
 {
   "format": 1,
   "restore": {
-    "C:\\Users\\brian\\source\\repos\\Card-Creator\\CardCreator\\CardCreator.csproj": {}
+    "/workspace/Card-Creator/CardCreator/CardCreator.csproj": {}
   },
   "projects": {
-    "C:\\Users\\brian\\source\\repos\\Card-Creator\\CardCreator\\CardCreator.csproj": {
+    "/workspace/Card-Creator/CardCreator/CardCreator.csproj": {
       "version": "1.0.0",
       "restore": {
-        "projectUniqueName": "C:\\Users\\brian\\source\\repos\\Card-Creator\\CardCreator\\CardCreator.csproj",
+        "projectUniqueName": "/workspace/Card-Creator/CardCreator/CardCreator.csproj",
         "projectName": "CardCreator",
-        "projectPath": "C:\\Users\\brian\\source\\repos\\Card-Creator\\CardCreator\\CardCreator.csproj",
-        "packagesPath": "C:\\Users\\brian\\.nuget\\packages\\",
-        "outputPath": "C:\\Users\\brian\\source\\repos\\Card-Creator\\CardCreator\\obj\\",
+        "projectPath": "/workspace/Card-Creator/CardCreator/CardCreator.csproj",
+        "packagesPath": "/root/.nuget/packages/",
+        "outputPath": "/workspace/Card-Creator/CardCreator/obj/",
         "projectStyle": "PackageReference",
-        "fallbackFolders": [
-          "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages"
-        ],
         "configFilePaths": [
-          "C:\\Users\\brian\\AppData\\Roaming\\NuGet\\NuGet.Config",
-          "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.FallbackLocation.config",
-          "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.Offline.config"
+          "/root/.nuget/NuGet/NuGet.Config"
         ],
         "originalTargetFrameworks": [
           "net8.0-windows"
         ],
         "sources": {
-          "C:\\Program Files (x86)\\Microsoft SDKs\\NuGetPackages\\": {},
-          "C:\\Program Files\\dotnet\\library-packs": {},
           "https://api.nuget.org/v3/index.json": {}
         },
         "frameworks": {
@@ -39,17 +32,17 @@
           "warnAsError": [
             "NU1605"
           ]
-        },
-        "restoreAuditProperties": {
-          "enableAudit": "true",
-          "auditLevel": "low",
-          "auditMode": "direct"
-        },
-        "SdkAnalysisLevel": "9.0.300"
+        }
       },
       "frameworks": {
         "net8.0-windows7.0": {
           "targetAlias": "net8.0-windows",
+          "dependencies": {
+            "Xceed.Wpf.Toolkit": {
+              "target": "Package",
+              "version": "[4.5.2, )"
+            }
+          },
           "imports": [
             "net461",
             "net462",
@@ -61,15 +54,18 @@
           ],
           "assetTargetFallback": true,
           "warn": true,
+          "downloadDependencies": [
+            {
+              "name": "Microsoft.WindowsDesktop.App.Ref",
+              "version": "[8.0.19, 8.0.19]"
+            }
+          ],
           "frameworkReferences": {
             "Microsoft.NETCore.App": {
               "privateAssets": "all"
-            },
-            "Microsoft.WindowsDesktop.App.WPF": {
-              "privateAssets": "none"
             }
           },
-          "runtimeIdentifierGraphPath": "C:\\Program Files\\dotnet\\sdk\\9.0.304/PortableRuntimeIdentifierGraph.json"
+          "runtimeIdentifierGraphPath": "/usr/lib/dotnet/sdk/8.0.119/PortableRuntimeIdentifierGraph.json"
         }
       }
     }

--- a/CardCreator/obj/CardCreator.csproj.nuget.g.props
+++ b/CardCreator/obj/CardCreator.csproj.nuget.g.props
@@ -4,13 +4,12 @@
     <RestoreSuccess Condition=" '$(RestoreSuccess)' == '' ">True</RestoreSuccess>
     <RestoreTool Condition=" '$(RestoreTool)' == '' ">NuGet</RestoreTool>
     <ProjectAssetsFile Condition=" '$(ProjectAssetsFile)' == '' ">$(MSBuildThisFileDirectory)project.assets.json</ProjectAssetsFile>
-    <NuGetPackageRoot Condition=" '$(NuGetPackageRoot)' == '' ">$(UserProfile)\.nuget\packages\</NuGetPackageRoot>
-    <NuGetPackageFolders Condition=" '$(NuGetPackageFolders)' == '' ">C:\Users\brian\.nuget\packages\;C:\Program Files (x86)\Microsoft Visual Studio\Shared\NuGetPackages</NuGetPackageFolders>
+    <NuGetPackageRoot Condition=" '$(NuGetPackageRoot)' == '' ">/root/.nuget/packages/</NuGetPackageRoot>
+    <NuGetPackageFolders Condition=" '$(NuGetPackageFolders)' == '' ">/root/.nuget/packages/</NuGetPackageFolders>
     <NuGetProjectStyle Condition=" '$(NuGetProjectStyle)' == '' ">PackageReference</NuGetProjectStyle>
-    <NuGetToolVersion Condition=" '$(NuGetToolVersion)' == '' ">6.14.1</NuGetToolVersion>
+    <NuGetToolVersion Condition=" '$(NuGetToolVersion)' == '' ">6.8.1</NuGetToolVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(ExcludeRestorePackageImports)' != 'true' ">
-    <SourceRoot Include="C:\Users\brian\.nuget\packages\" />
-    <SourceRoot Include="C:\Program Files (x86)\Microsoft Visual Studio\Shared\NuGetPackages\" />
+    <SourceRoot Include="/root/.nuget/packages/" />
   </ItemGroup>
 </Project>

--- a/CardCreator/obj/project.assets.json
+++ b/CardCreator/obj/project.assets.json
@@ -1,39 +1,67 @@
 {
   "version": 3,
   "targets": {
-    "net8.0-windows7.0": {}
+    "net8.0-windows7.0": {
+      "Xceed.Wpf.Toolkit/4.5.22477.12540": {
+        "type": "package",
+        "compile": {
+          "lib/net5.0/Xceed.Wpf.Toolkit.NET5.dll": {
+            "related": ".xml"
+          }
+        },
+        "runtime": {
+          "lib/net5.0/Xceed.Wpf.Toolkit.NET5.dll": {
+            "related": ".xml"
+          }
+        }
+      }
+    }
   },
-  "libraries": {},
+  "libraries": {
+    "Xceed.Wpf.Toolkit/4.5.22477.12540": {
+      "sha512": "GjxsRf37xSyYgsF/r47kgntyZxIHM0uHmyXZZEmu9YWbss8KRkbeMdvUmjb00HlVR8aB2qCwTNktaB7+ZiMzMw==",
+      "type": "package",
+      "path": "xceed.wpf.toolkit/4.5.22477.12540",
+      "files": [
+        ".nupkg.metadata",
+        ".signature.p7s",
+        "License Agreement.txt",
+        "images/Toolkit.png",
+        "lib/net40/Xceed.Wpf.Toolkit.dll",
+        "lib/net40/Xceed.Wpf.Toolkit.xml",
+        "lib/net5.0/Xceed.Wpf.Toolkit.NET5.dll",
+        "lib/net5.0/Xceed.Wpf.Toolkit.NET5.xml",
+        "lib/netcoreapp3.0/Xceed.Wpf.Toolkit.NETCore.dll",
+        "lib/netcoreapp3.0/Xceed.Wpf.Toolkit.NETCore.xml",
+        "xceed.wpf.toolkit.4.5.22477.12540.nupkg.sha512",
+        "xceed.wpf.toolkit.nuspec"
+      ]
+    }
+  },
   "projectFileDependencyGroups": {
-    "net8.0-windows7.0": []
+    "net8.0-windows7.0": [
+      "Xceed.Wpf.Toolkit >= 4.5.2"
+    ]
   },
   "packageFolders": {
-    "C:\\Users\\brian\\.nuget\\packages\\": {},
-    "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages": {}
+    "/root/.nuget/packages/": {}
   },
   "project": {
     "version": "1.0.0",
     "restore": {
-      "projectUniqueName": "C:\\Users\\brian\\source\\repos\\Card-Creator\\CardCreator\\CardCreator.csproj",
+      "projectUniqueName": "/workspace/Card-Creator/CardCreator/CardCreator.csproj",
       "projectName": "CardCreator",
-      "projectPath": "C:\\Users\\brian\\source\\repos\\Card-Creator\\CardCreator\\CardCreator.csproj",
-      "packagesPath": "C:\\Users\\brian\\.nuget\\packages\\",
-      "outputPath": "C:\\Users\\brian\\source\\repos\\Card-Creator\\CardCreator\\obj\\",
+      "projectPath": "/workspace/Card-Creator/CardCreator/CardCreator.csproj",
+      "packagesPath": "/root/.nuget/packages/",
+      "outputPath": "/workspace/Card-Creator/CardCreator/obj/",
       "projectStyle": "PackageReference",
-      "fallbackFolders": [
-        "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages"
-      ],
       "configFilePaths": [
-        "C:\\Users\\brian\\AppData\\Roaming\\NuGet\\NuGet.Config",
-        "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.FallbackLocation.config",
-        "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.Offline.config"
+        "/root/.nuget/NuGet/NuGet.Config"
       ],
       "originalTargetFrameworks": [
         "net8.0-windows"
       ],
       "sources": {
-        "C:\\Program Files (x86)\\Microsoft SDKs\\NuGetPackages\\": {},
-        "C:\\Program Files\\dotnet\\library-packs": {},
         "https://api.nuget.org/v3/index.json": {}
       },
       "frameworks": {
@@ -46,17 +74,17 @@
         "warnAsError": [
           "NU1605"
         ]
-      },
-      "restoreAuditProperties": {
-        "enableAudit": "true",
-        "auditLevel": "low",
-        "auditMode": "direct"
-      },
-      "SdkAnalysisLevel": "9.0.300"
+      }
     },
     "frameworks": {
       "net8.0-windows7.0": {
         "targetAlias": "net8.0-windows",
+        "dependencies": {
+          "Xceed.Wpf.Toolkit": {
+            "target": "Package",
+            "version": "[4.5.2, )"
+          }
+        },
         "imports": [
           "net461",
           "net462",
@@ -68,16 +96,31 @@
         ],
         "assetTargetFallback": true,
         "warn": true,
+        "downloadDependencies": [
+          {
+            "name": "Microsoft.WindowsDesktop.App.Ref",
+            "version": "[8.0.19, 8.0.19]"
+          }
+        ],
         "frameworkReferences": {
           "Microsoft.NETCore.App": {
             "privateAssets": "all"
-          },
-          "Microsoft.WindowsDesktop.App.WPF": {
-            "privateAssets": "none"
           }
         },
-        "runtimeIdentifierGraphPath": "C:\\Program Files\\dotnet\\sdk\\9.0.304/PortableRuntimeIdentifierGraph.json"
+        "runtimeIdentifierGraphPath": "/usr/lib/dotnet/sdk/8.0.119/PortableRuntimeIdentifierGraph.json"
       }
     }
-  }
+  },
+  "logs": [
+    {
+      "code": "NU1603",
+      "level": "Warning",
+      "warningLevel": 1,
+      "message": "CardCreator depends on Xceed.Wpf.Toolkit (>= 4.5.2) but Xceed.Wpf.Toolkit 4.5.2 was not found. An approximate best match of Xceed.Wpf.Toolkit 4.5.22477.12540 was resolved.",
+      "libraryId": "Xceed.Wpf.Toolkit",
+      "targetGraphs": [
+        "net8.0-windows7.0"
+      ]
+    }
+  ]
 }

--- a/CardCreator/obj/project.nuget.cache
+++ b/CardCreator/obj/project.nuget.cache
@@ -1,8 +1,22 @@
 {
   "version": 2,
-  "dgSpecHash": "iq0NR1qR4wI=",
+  "dgSpecHash": "/U/hAHrQ+kvQPjvbQeYqHF+Urbl1e+bh1UUpOESIA+LNiL73GZAvsvPl+9EZx4qNfhkQHCS8Us8rt+adwyej8A==",
   "success": true,
-  "projectFilePath": "C:\\Users\\brian\\source\\repos\\Card-Creator\\CardCreator\\CardCreator.csproj",
-  "expectedPackageFiles": [],
-  "logs": []
+  "projectFilePath": "/workspace/Card-Creator/CardCreator/CardCreator.csproj",
+  "expectedPackageFiles": [
+    "/root/.nuget/packages/xceed.wpf.toolkit/4.5.22477.12540/xceed.wpf.toolkit.4.5.22477.12540.nupkg.sha512",
+    "/root/.nuget/packages/microsoft.windowsdesktop.app.ref/8.0.19/microsoft.windowsdesktop.app.ref.8.0.19.nupkg.sha512"
+  ],
+  "logs": [
+    {
+      "code": "NU1603",
+      "level": "Warning",
+      "warningLevel": 1,
+      "message": "CardCreator depends on Xceed.Wpf.Toolkit (>= 4.5.2) but Xceed.Wpf.Toolkit 4.5.2 was not found. An approximate best match of Xceed.Wpf.Toolkit 4.5.22477.12540 was resolved.",
+      "libraryId": "Xceed.Wpf.Toolkit",
+      "targetGraphs": [
+        "net8.0-windows7.0"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- show each font in its own style and offer common sizes with editable font size list
- implement manual strikethrough and transparent backgrounds for editable text boxes
- allow dragging selected RichTextBox items and keep templates hit-testable when loading
- resolve RichTextBox selection errors by defaulting to the text box when clicking inside its document
- add toolbar button to insert images into rich text
- propagate canvas RichTextBox edits to card data by raising inspector text updates
- apply font family, size, and color changes to the current selection and store formatting inside the FlowDocument
- move selection-change handler into the view model and expose toolbar formatting helper to correct class bracing
- clear element selection before exporting cards to images or sheets
- remove default border around generated RichTextBoxes by nulling border and focus styles
- allow deselection with escape or clicking the workspace and add 1px grid snapping option
- ensure inspector width, height, and rotation updates reflect on selected elements

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-8.0`
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c442c34f908326a27befa99622e200