### PR TITLE
Limit inline image size and block drag

### DIFF
--- a/CardCreator/MainWindow.xaml.cs
+++ b/CardCreator/MainWindow.xaml.cs
@@ -447,9 +447,7 @@ public class MainViewModel : INotifyPropertyChanged
             return;
         var pos = e.GetPosition(_canvas);
         var source = e.OriginalSource as DependencyObject;
-        if (source is Thumb thumb &&
-            FindAncestor<Grid>(thumb) is Grid g &&
-            g.Parent is InlineUIContainer)
+        if (FindAncestor<InlineUIContainer>(source) != null)
             return;
         if (e.OriginalSource == _canvas)
         {
@@ -720,17 +718,22 @@ public class MainViewModel : INotifyPropertyChanged
 
     public Grid CreateRtbImageContainer(BitmapSource source)
     {
+        double scale = Math.Min(100.0 / source.PixelWidth, 100.0 / source.PixelHeight);
+        if (scale > 1)
+            scale = 1;
+        double width = source.PixelWidth * scale;
+        double height = source.PixelHeight * scale;
         var img = new Image
         {
             Source = source,
-            Width = source.PixelWidth,
-            Height = source.PixelHeight,
+            Width = width,
+            Height = height,
             Stretch = Stretch.Uniform
         };
         var container = new Grid
         {
-            Width = img.Width,
-            Height = img.Height,
+            Width = width,
+            Height = height,
             Background = Brushes.Transparent
         };
         container.Children.Add(img);


### PR DESCRIPTION
## Summary
- Limit RichTextBox inline image default dimensions to 100px or source size while preserving aspect ratio
- Prevent canvas drag when clicking inline images so resizing handles work

## Testing
- `dotnet build` *(fails: The imported project ... Microsoft.NET.Sdk.WindowsDesktop.targets was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7479a811c8326af73a2d996262b8c