### PR TITLE
Handle inline image clicks via RichTextBox

### DIFF
--- a/CardCreator/MainWindow.xaml.cs
+++ b/CardCreator/MainWindow.xaml.cs
@@ -703,6 +703,7 @@ public class MainViewModel : INotifyPropertyChanged
         {
             rtb.TextChanged += CanvasRichTextBox_TextChanged;
             rtb.SelectionChanged += CanvasRichTextBox_SelectionChanged;
+            AttachRichTextImages(rtb);
         }
         AttachContainerChrome(container);
         if (useSnap && SnapEnabled)
@@ -754,25 +755,22 @@ public class MainViewModel : INotifyPropertyChanged
 
     private void InlineImage_PreviewMouseLeftButtonDown(object? sender, MouseButtonEventArgs e)
     {
-        e.Handled = true;
-        Grid? grid = sender as Grid;
-        if (grid == null && sender is Image img && img.Parent is Grid g)
-            grid = g;
-        if (grid == null)
-            return;
-        ClearSelection();
-        _selectedRtbImage = grid;
-        if (grid.Children.Count > 1 && grid.Children[1] is Border b)
-            b.Visibility = Visibility.Visible;
-        Inspector.SetElement((FrameworkElement)grid.Children[0]);
+        var iuic = FindAncestor<InlineUIContainer>(e.OriginalSource as DependencyObject);
+        if (iuic?.Child is Grid grid)
+        {
+            e.Handled = true;
+            ClearSelection();
+            _selectedRtbImage = grid;
+            if (grid.Children.Count > 1 && grid.Children[1] is Border b)
+                b.Visibility = Visibility.Visible;
+            Inspector.SetElement((FrameworkElement)grid.Children[0]);
+        }
     }
 
     private void AttachInlineImageChrome(Grid container)
     {
         if (container.Children.Count == 0 || container.Children[0] is not Image img)
             return;
-        container.PreviewMouseLeftButtonDown += InlineImage_PreviewMouseLeftButtonDown;
-        img.PreviewMouseLeftButtonDown += InlineImage_PreviewMouseLeftButtonDown;
         var selBorder = new Border
         {
             BorderBrush = new SolidColorBrush(Color.FromArgb(200, 0, 120, 215)),
@@ -787,6 +785,7 @@ public class MainViewModel : INotifyPropertyChanged
 
     internal void AttachRichTextImages(RichTextBox rtb)
     {
+        rtb.AddHandler(UIElement.PreviewMouseLeftButtonDownEvent, InlineImage_PreviewMouseLeftButtonDown, true);
         TextPointer pointer = rtb.Document.ContentStart;
         while (pointer != null && pointer.CompareTo(rtb.Document.ContentEnd) < 0)
         {


### PR DESCRIPTION
## Summary
- capture inline image clicks at the RichTextBox level
- locate inline image containers from preview events and update inspector
- remove redundant per-image click subscriptions

## Testing
- `dotnet build CardCreator.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c756cd92208326b17d80e3c67f3a91