### PR TITLE
Add custom color picker dialog

### DIFF
--- a/CardCreator/ColorPickerDialog.xaml
+++ b/CardCreator/ColorPickerDialog.xaml
@@ -1,0 +1,65 @@
+<Window x:Class="CardCreator.ColorPickerDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Select Color"
+        SizeToContent="WidthAndHeight"
+        MinWidth="320"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="NoResize">
+    <Grid Margin="12">
+        <Grid.Resources>
+            <Style TargetType="TextBox">
+                <Setter Property="Width" Value="50" />
+                <Setter Property="Margin" Value="8,0,0,0" />
+                <Setter Property="HorizontalContentAlignment" Value="Center" />
+            </Style>
+            <Style TargetType="Slider">
+                <Setter Property="Minimum" Value="0" />
+                <Setter Property="Maximum" Value="255" />
+                <Setter Property="Margin" Value="8,0,0,0" />
+                <Setter Property="TickFrequency" Value="1" />
+                <Setter Property="IsSnapToTickEnabled" Value="True" />
+            </Style>
+            <Style TargetType="Label">
+                <Setter Property="VerticalAlignment" Value="Center" />
+                <Setter Property="Width" Value="50" />
+            </Style>
+        </Grid.Resources>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="Auto" />
+        </Grid.ColumnDefinitions>
+
+        <Label Grid.Row="0" Grid.Column="0" Content="Red" />
+        <Slider Grid.Row="0" Grid.Column="1" Value="{Binding Red, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+        <TextBox Grid.Row="0" Grid.Column="2" Text="{Binding Red, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, StringFormat=F0}" />
+
+        <Label Grid.Row="1" Grid.Column="0" Content="Green" />
+        <Slider Grid.Row="1" Grid.Column="1" Value="{Binding Green, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+        <TextBox Grid.Row="1" Grid.Column="2" Text="{Binding Green, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, StringFormat=F0}" />
+
+        <Label Grid.Row="2" Grid.Column="0" Content="Blue" />
+        <Slider Grid.Row="2" Grid.Column="1" Value="{Binding Blue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+        <TextBox Grid.Row="2" Grid.Column="2" Text="{Binding Blue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, StringFormat=F0}" />
+
+        <Label Grid.Row="3" Grid.Column="0" Content="Alpha" />
+        <Slider Grid.Row="3" Grid.Column="1" Value="{Binding Alpha, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+        <TextBox Grid.Row="3" Grid.Column="2" Text="{Binding Alpha, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, StringFormat=F0}" />
+
+        <Border Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="3" Height="60" Margin="0,12,0,12" BorderBrush="Gray" BorderThickness="1" CornerRadius="4" Background="{Binding PreviewBrush}" />
+
+        <StackPanel Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="3" Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button Width="75" Margin="0,0,8,0" IsDefault="True" Content="OK" Click="Ok_Click" />
+            <Button Width="75" IsCancel="True" Content="Cancel" />
+        </StackPanel>
+    </Grid>
+</Window>

--- a/CardCreator/ColorPickerDialog.xaml.cs
+++ b/CardCreator/ColorPickerDialog.xaml.cs
@@ -1,0 +1,106 @@
+using System;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Windows;
+using System.Windows.Media;
+
+namespace CardCreator
+{
+    public partial class ColorPickerDialog : Window, INotifyPropertyChanged
+    {
+        private double _red;
+        private double _green;
+        private double _blue;
+        private double _alpha;
+        private Brush _previewBrush = Brushes.Transparent;
+
+        public ColorPickerDialog()
+        {
+            InitializeComponent();
+            DataContext = this;
+            UpdatePreview();
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        public double Red
+        {
+            get => _red;
+            set
+            {
+                if (SetField(ref _red, Clamp(value)))
+                    UpdatePreview();
+            }
+        }
+
+        public double Green
+        {
+            get => _green;
+            set
+            {
+                if (SetField(ref _green, Clamp(value)))
+                    UpdatePreview();
+            }
+        }
+
+        public double Blue
+        {
+            get => _blue;
+            set
+            {
+                if (SetField(ref _blue, Clamp(value)))
+                    UpdatePreview();
+            }
+        }
+
+        public double Alpha
+        {
+            get => _alpha;
+            set
+            {
+                if (SetField(ref _alpha, Clamp(value)))
+                    UpdatePreview();
+            }
+        }
+
+        public Brush PreviewBrush
+        {
+            get => _previewBrush;
+            private set => SetField(ref _previewBrush, value);
+        }
+
+        public Color SelectedColor
+        {
+            get => Color.FromArgb((byte)Math.Round(Alpha), (byte)Math.Round(Red), (byte)Math.Round(Green), (byte)Math.Round(Blue));
+            set
+            {
+                Alpha = value.A;
+                Red = value.R;
+                Green = value.G;
+                Blue = value.B;
+            }
+        }
+
+        private static double Clamp(double value) => Math.Min(255, Math.Max(0, value));
+
+        private bool SetField<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+        {
+            if (Equals(field, value))
+                return false;
+            field = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+            return true;
+        }
+
+        private void UpdatePreview()
+        {
+            var color = SelectedColor;
+            PreviewBrush = new SolidColorBrush(color);
+        }
+
+        private void Ok_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = true;
+        }
+    }
+}

--- a/CardCreator/MainWindow.xaml.cs
+++ b/CardCreator/MainWindow.xaml.cs
@@ -107,12 +107,15 @@ public partial class MainWindow : Window
     {
         if (VM.Inspector.Element is not RichTextBox rtb)
             return;
-        var dlg = new WinForms.ColorDialog();
         var c = GetSelectionColor(rtb);
-        dlg.Color = DrawingColor.FromArgb(c.A, c.R, c.G, c.B);
-        if (dlg.ShowDialog() == WinForms.DialogResult.OK)
+        var dlg = new ColorPickerDialog
         {
-            var color = Color.FromArgb(dlg.Color.A, dlg.Color.R, dlg.Color.G, dlg.Color.B);
+            Owner = this,
+            SelectedColor = Color.FromArgb(c.A, c.R, c.G, c.B)
+        };
+        if (dlg.ShowDialog() == true)
+        {
+            var color = dlg.SelectedColor;
             var sel = new TextRange(rtb.Selection.Start, rtb.Selection.End);
             sel.ApplyPropertyValue(TextElement.ForegroundProperty, new SolidColorBrush(color));
             UpdateFontToolbarFormatting();
@@ -121,11 +124,18 @@ public partial class MainWindow : Window
     }
     private void PickBackgroundColor_Click(object s, RoutedEventArgs e)
     {
-        var dlg = new WinForms.ColorDialog();
-        dlg.Color = DrawingColor.FromArgb(_richTextBackgroundColor.A, _richTextBackgroundColor.R, _richTextBackgroundColor.G, _richTextBackgroundColor.B);
-        if (dlg.ShowDialog() == WinForms.DialogResult.OK)
+        var dlg = new ColorPickerDialog
         {
-            var color = Color.FromArgb(dlg.Color.A, dlg.Color.R, dlg.Color.G, dlg.Color.B);
+            Owner = this,
+            SelectedColor = Color.FromArgb(
+                _richTextBackgroundColor.A,
+                _richTextBackgroundColor.R,
+                _richTextBackgroundColor.G,
+                _richTextBackgroundColor.B)
+        };
+        if (dlg.ShowDialog() == true)
+        {
+            var color = dlg.SelectedColor;
             _richTextBackgroundColor = color;
             if (VM.Inspector.Element is RichTextBox rtb)
             {


### PR DESCRIPTION
## Summary
- add a dedicated WPF color picker dialog with RGBA sliders, numeric inputs, and preview
- replace the WinForms color dialog usage with the custom dialog for text and background selection

## Testing
- `dotnet build` *(fails: `dotnet` CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc9a0e09a08326bc2df7ed5ed1bf78