### PR TITLE
Respect Z order when loading templates

### DIFF
--- a/CardCreator/Services/TemplateSerializer.cs
+++ b/CardCreator/Services/TemplateSerializer.cs
@@ -82,6 +82,7 @@ namespace CardCreator.Services {
         if(!string.IsNullOrWhiteSpace(item.ControlName)) { inner.Tag=item.ControlName; container.Tag=item.ControlName; }
         container.Children.Add(inner);
         Canvas.SetLeft(container,item.X); Canvas.SetTop(container,item.Y);
+        Panel.SetZIndex(container,item.Z);
         canvas.Children.Add(container);
       }
       return model;


### PR DESCRIPTION
## Summary
- ensure loaded template elements respect their saved Z order by applying the stored value to each container's Panel.ZIndex

## Testing
- ⚠️ `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ccc16311a88326afdf5feff1281ca9