### PR TITLE
Ensure image containers remain transparent

### DIFF
--- a/CardCreator/MainWindow.xaml.cs
+++ b/CardCreator/MainWindow.xaml.cs
@@ -996,8 +996,8 @@ namespace CardCreator
                     double w = fe.Width;
                     double h = fe.Height;
                     var container = CreateContainer(fe, item.X, item.Y, w, h, useSnap: false);
-                    if (fe is Image img && img.Visibility == Visibility.Visible && img.Source != null)
-                        container.Background = Brushes.White;
+                    if (fe is Image)
+                        container.Background = Brushes.Transparent;
                     if (fe.Tag is string t && !string.IsNullOrWhiteSpace(t))
                         container.Tag = t;
                     _canvas.Children.Add(container);
@@ -1471,8 +1471,8 @@ namespace CardCreator
             if (field.Hidden.HasValue)
             {
                 el.Visibility = field.Hidden.Value ? Visibility.Hidden : Visibility.Visible;
-                if (el.Parent is Grid g && el is Image img)
-                    g.Background = (field.Hidden.Value || img.Source == null) ? Brushes.Transparent : Brushes.White;
+                if (el.Parent is Grid g && el is Image)
+                    g.Background = Brushes.Transparent;
             }
             if (el is RichTextBox tb)
             {
@@ -1502,6 +1502,8 @@ namespace CardCreator
                 }
                 if (field.Stretch != null && Enum.TryParse<Stretch>(field.Stretch, out var st))
                     img.Stretch = st;
+                if (img.Parent is Grid grid)
+                    grid.Background = Brushes.Transparent;
             }
         }
 

--- a/CardCreator/Models/SelectedElementViewModel.cs
+++ b/CardCreator/Models/SelectedElementViewModel.cs
@@ -146,8 +146,8 @@ namespace CardCreator.Models {
       set {
         if (Element == null) return;
         Element.Visibility = value ? Visibility.Hidden : Visibility.Visible;
-        if (Element.Parent is Grid g && Element is Image img)
-          g.Background = (value || img.Source == null) ? Brushes.Transparent : Brushes.White;
+        if (Element.Parent is Grid g && Element is Image)
+          g.Background = Brushes.Transparent;
         OnPropertyChanged();
       }
     }

--- a/CardCreator/Services/TemplateSerializer.cs
+++ b/CardCreator/Services/TemplateSerializer.cs
@@ -85,7 +85,7 @@ namespace CardCreator.Services {
         if(!string.IsNullOrWhiteSpace(item.ControlName)) inner.Name=item.ControlName;
         inner.RenderTransformOrigin=new Point(0.5,0.5);
         ApplyRotation(inner, item.Rotation);
-        var container=new Grid{ Background=item.Type=="Image" ? (item.Hidden==true || string.IsNullOrWhiteSpace(item.Source) ? Brushes.Transparent : Brushes.White) : Brushes.Transparent, Width=item.Width, Height=item.Height };
+        var container=new Grid{ Background=Brushes.Transparent, Width=item.Width, Height=item.Height };
         if(!string.IsNullOrWhiteSpace(item.ControlName)) { inner.Tag=item.ControlName; container.Tag=item.ControlName; }
         container.Children.Add(inner);
         Canvas.SetLeft(container,item.X); Canvas.SetTop(container,item.Y);


### PR DESCRIPTION
## Summary
- keep restored canvas containers for images transparent instead of switching to white backgrounds
- ensure inspector toggling and field application do not introduce opaque image container fills
- load serialized image containers with transparent backgrounds so saved templates preserve transparency

## Testing
- `dotnet build CardCreator.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68cccbf8e1288326878df5a0f8afa881